### PR TITLE
Improve 'debug console'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,16 @@ endif(LUA_FOUND)
 
 if(DUMB_FOUND)
 	message(STATUS "DUMB found at ${DUMB_INCLUDE_DIR}")
+	# assume dumb's allegro support is here too
+	set(AL_DUMB_LIBRARIES "-laldmb")
 endif(DUMB_FOUND)
 
+if (DUMB_FOUND AND ALLEGRO_FOUND)
+endif(DUMB_FOUND AND ALLEGRO_FOUND)
+
 include_directories( ${ALLEGRO_INCLUDE_DIR} ${LUA_INCLUDE_DIR} ${DUMB_INCLUDE_DIR} )
+set(KQ_DEBUGGING 0 CACHE BOOL "Features for debugging the game")
+
 
 set(kq-fork_SRCS
 	src/bounds.c
@@ -60,11 +67,19 @@ set(kq-fork_SRCS
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 set(CMAKE_C_FLAGS "-O0 -ggdb3 -Wall -Wextra -Wpedantic -std=c99")
-set(ALLEGRO_LIBRARY "-lalleg")
-set(LUA_LIBRARY "-llua")
-set(DUMB_LIBRARY "-laldmb -ldumb")
+#set(ALLEGRO_LIBRARY "-lalleg")
+#set(DUMB_LIBRARY "-laldmb -ldumb")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(kq-fork ${kq-fork_SRCS})
 
-target_link_libraries(kq-fork ${ALLEGRO_LIBRARY} ${LUA_LIBRARY} ${DUMB_LIBRARY} ${M_LIB})
+if(KQ_DEBUGGING)
+set_target_properties(kq-fork PROPERTIES COMPILE_DEFINITIONS DEBUGMODE)
+endif(KQ_DEBUGGING)
+
+target_link_libraries(kq-fork 
+  ${ALLEGRO_LIBRARIES} 
+  ${LUA_LIBRARY} 
+  ${AL_DUMB_LIBRARIES} 
+  ${DUMB_LIBRARIES} 
+  ${M_LIB})

--- a/FindAllegro.cmake
+++ b/FindAllegro.cmake
@@ -1,7 +1,4 @@
 # - Try to find Allegro
-# Configs for lookup
-#  ALLEGRO_PATH_SUFFIX - suffix for include path, allegro or alllegro5
-#
 # Once done this will define
 #
 #  ALLEGRO_FOUND - system has Allegro
@@ -15,14 +12,12 @@
 #  BSD license.
 #  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 #
-if (ALLEGRO_INCLUDE_DIRS)
+
+
+if (ALLEGRO_LIBRARIES AND ALLEGRO_INCLUDE_DIRS)
   # in cache already
   set(ALLEGRO_FOUND TRUE)
 else (ALLEGRO_LIBRARIES AND ALLEGRO_INCLUDE_DIRS)
-  if (NOT DEFINED ALLEGRO_PATH_SUFFIX)
-    set(ALLEGRO_PATH_SUFFIX allegro)
-  endif()
-
   find_path(ALLEGRO_INCLUDE_DIR
     NAMES
       allegro.h
@@ -32,26 +27,42 @@ else (ALLEGRO_LIBRARIES AND ALLEGRO_INCLUDE_DIRS)
       /opt/local/include
       /sw/include
     PATH_SUFFIXES
-      "${ALLEGRO_PATH_SUFFIX}"
+      allegro
+  )
+
+  find_library(ALLEG_LIBRARY
+    NAMES
+      alleg
+    PATHS
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
   )
 
   set(ALLEGRO_INCLUDE_DIRS
     ${ALLEGRO_INCLUDE_DIR}
   )
+  set(ALLEGRO_LIBRARIES
+    ${ALLEG_LIBRARY}
+)
 
-  if (ALLEGRO_INCLUDE_DIRS)
+  if (ALLEGRO_INCLUDE_DIRS AND ALLEGRO_LIBRARIES)
      set(ALLEGRO_FOUND TRUE)
-  endif (ALLEGRO_INCLUDE_DIRS)
+  endif (ALLEGRO_INCLUDE_DIRS AND ALLEGRO_LIBRARIES)
 
   if (ALLEGRO_FOUND)
+    if (NOT Allegro_FIND_QUIETLY)
+      message(STATUS "Found Allegro: ${ALLEGRO_LIBRARIES}")
+    endif (NOT Allegro_FIND_QUIETLY)
   else (ALLEGRO_FOUND)
     if (Allegro_FIND_REQUIRED)
       message(FATAL_ERROR "Could not find Allegro")
     endif (Allegro_FIND_REQUIRED)
   endif (ALLEGRO_FOUND)
 
-  # show the ALLEGRO_INCLUDE_DIRS variables only in the advanced view
-  mark_as_advanced(ALLEGRO_INCLUDE_DIRS)
+  # show the ALLEGRO_INCLUDE_DIRS and ALLEGRO_LIBRARIES variables only in the advanced view
+  mark_as_advanced(ALLEGRO_INCLUDE_DIRS ALLEGRO_LIBRARIES)
 
-endif (ALLEGRO_INCLUDE_DIRS)
+endif (ALLEGRO_LIBRARIES AND ALLEGRO_INCLUDE_DIRS)
 

--- a/src/console.c
+++ b/src/console.c
@@ -143,9 +143,9 @@ void run_console(void)
     int running;
     unsigned int string_len;
     unsigned int i;
-    const char get[] = "return get_progress(P_";
-    const char ret[] = "return ";
-    const char set[] = "set_progress(P_";
+    static const char get[] = "return get_progress(P_";
+    static const char ret[] = "return ";
+    static const char set[] = "set_progress(P_";
 
     g_console.inputline[0] = '\0';
     g_console.on = 1;


### PR DESCRIPTION
This is a small improvement to the debug console (accessed by pressing backslash \\) when DEBUGMODE is compiled in.

Previously if you tried to print a value that wasn't a number or string it would just print nothing at all. Now it prints bools correctly, or  one of \<NIL>, \<TABLE>, \<FUNCTION>, \<USERDATA> as appropriate.

Please review. I had to make some changes to the CMake files to add an option to compile in DEBUGMODE support, and also I found that FindAllegro.cmake was missing the bit that sets the library name. I don't know if there was a reason the original author did it this way.