### PR TITLE
More fixes for VS2015

### DIFF
--- a/src/credits.cpp
+++ b/src/credits.cpp
@@ -164,6 +164,7 @@ void display_credits(BITMAP *double_buffer)
         /* Put an un-ignorable cheat message; this should stop
          * PH releasing versions with cheat mode compiled in ;)
          */
+		extern int cheat;
         print_font(double_buffer, 80, 40, cheat ? _("*CHEAT MODE ON*") : _("*CHEAT MODE OFF*"), FGOLD);
 #endif
 #ifdef DEBUGMODE

--- a/src/credits.cpp
+++ b/src/credits.cpp
@@ -103,7 +103,7 @@ void allocate_credits(void)
     // are integer division, so should 
     for (ease_index = 0; ease_index < NUM_EASE_VALUES; ++ease_index)
     {
-        ease_table[ease_index] = ease_index * ease_index * (3 * NUM_EASE_VALUES - 2 * ease_index) / NUM_EASE_VALUES / NUM_EASE_VALUES;
+        ease_table[ease_index] = short(ease_index * ease_index * (3 * NUM_EASE_VALUES - 2 * ease_index) / NUM_EASE_VALUES / NUM_EASE_VALUES);
     }
     cc = credits;
     LOCK_FUNCTION(ticker);

--- a/src/eqpmenu.cpp
+++ b/src/eqpmenu.cpp
@@ -341,7 +341,7 @@ static void draw_equippable(unsigned int c, unsigned int slot, unsigned int pptr
     }
     if (tot < NUM_ITEMS_PER_PAGE)
     {
-        sm = tot;
+        sm = unsigned short(tot);
     }
     else
     {

--- a/src/itemmenu.cpp
+++ b/src/itemmenu.cpp
@@ -319,13 +319,13 @@ int check_inventory(size_t inventory_index, int item_quantity)
     if (d < MAX_INV)
     {
         // This is redundant, but it is a good error-check
-        g_inv[d][GLOBAL_INVENTORY_ITEM] = inventory_index;
+        g_inv[d][GLOBAL_INVENTORY_ITEM] = unsigned short(inventory_index);
         // Add item_quantity to this item's quantity
         g_inv[d][GLOBAL_INVENTORY_QUANTITY] += item_quantity;
         return 1;
     }
     // Add item to new slot
-    g_inv[v][GLOBAL_INVENTORY_ITEM] = inventory_index;
+    g_inv[v][GLOBAL_INVENTORY_ITEM] = unsigned short(inventory_index);
     // Fill in item's quantity too
     g_inv[v][GLOBAL_INVENTORY_QUANTITY] += item_quantity;
     return 2;

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -1635,7 +1635,7 @@ static void prepare_map(int msx, int msy, int mvx, int mvy)
 
     for (i = 0; i < MAX_TILES; i++)
     {
-        tilex[i] = i;
+        tilex[i] = unsigned short(i);
     }
     for (i = 0; i < MAX_ANIM; i++)
     {


### PR DESCRIPTION
There were a couple more warnings relating to casting down from `size_t`

Also, if it is compiled with KQ_CHEATS defined, an extern reference to a variable needs to be added.