### PR TITLE
Add and use a new constant, MAX_ENTITIES.

### DIFF
--- a/include/enums.h
+++ b/include/enums.h
@@ -85,6 +85,7 @@ enum eGlobalInventory
 #define WINDOW_TILES_W     21
 #define WINDOW_TILES_H     16
 #define MAX_ENTITIES_PER_MAP 50
+#define MAX_ENTITIES (MAX_ENTITIES_PER_MAP + PSIZE)
 #define ID_ENEMY          254
 #define ENT_FRAMES_PER_DIR  3
 

--- a/include/kq.h
+++ b/include/kq.h
@@ -137,7 +137,7 @@ extern unsigned char treasure[SIZE_TREASURE];
 extern unsigned char save_spells[SIZE_SAVE_SPELL];
 extern BITMAP *kfonts;
 extern s_map g_map;
-extern s_entity g_ent[MAX_ENTITIES_PER_MAP + PSIZE];
+extern s_entity g_ent[MAX_ENTITIES];
 extern s_anim tanim[MAX_TILESETS][MAX_ANIM];
 extern s_anim adata[MAX_ANIM];
 extern unsigned int numchrs;

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -2053,12 +2053,12 @@ void revert_cframes(size_t fighter_index, int revert_heroes)
  * The purpose of this function is to calculate where a text bubble
  * should go in relation to the entity who is speaking.
  *
- * \param   entity_index If value is between 0..MAX_ENTITIES_PER_MAP (exclusive),
+ * \param   entity_index If value is between 0..MAX_ENTITIES (exclusive),
  *              character that is speaking, otherwise 'general'.
  */
 static void set_textpos(unsigned int entity_index)
 {
-    if (entity_index < MAX_ENTITIES_PER_MAP)
+    if (entity_index < MAX_ENTITIES)
     {
         gbx = (g_ent[entity_index].tilex * TILE_W) - vx;
         gby = (g_ent[entity_index].tiley * TILE_H) - vy;

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -134,13 +134,15 @@ static void chase(t_entity target_entity)
 /*! \brief Count active entities
  *
  * Force calculation of the 'noe' variable.
+ * This actually calculates the last index of any active entity plus one,
+ * so if there are entities present, but not active, they may be counted.
  */
 void count_entities(void)
 {
     size_t entity_index;
 
     noe = 0;
-    for (entity_index = 0; entity_index < MAX_ENTITIES_PER_MAP; entity_index++)
+    for (entity_index = 0; entity_index < MAX_ENTITIES; entity_index++)
     {
         if (g_ent[entity_index].active == 1)
         {
@@ -209,7 +211,7 @@ int entityat(int ox, int oy, t_entity who)
 {
     t_entity i;
 
-    for (i = 0; i < MAX_ENTITIES_PER_MAP; i++)
+    for (i = 0; i < MAX_ENTITIES; i++)
     {
         if (g_ent[i].active && ox == g_ent[i].tilex && oy == g_ent[i].tiley)
         {
@@ -700,7 +702,7 @@ static int obstruction(int origin_x, int origin_y, int move_x, int move_y, int c
     // Another entity blocks movement as well
     if (check_entity)
     {
-        for (i = 0; i < MAX_ENTITIES_PER_MAP; i++)
+        for (i = 0; i < MAX_ENTITIES; i++)
         {
             if (g_ent[i].active
              && dest_x == g_ent[i].tilex
@@ -813,7 +815,7 @@ void process_entities(void)
     t_entity i;
     const char *t_evt;
 
-    for (i = 0; i < MAX_ENTITIES_PER_MAP; i++)
+    for (i = 0; i < MAX_ENTITIES; i++)
     {
         if (g_ent[i].active == 1)
         {

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -125,7 +125,7 @@ unsigned char save_spells[SIZE_SAVE_SPELL];
 s_map g_map;
 
 /*! Current entities (players+NPCs) */
-s_entity g_ent[MAX_ENTITIES_PER_MAP + PSIZE];
+s_entity g_ent[MAX_ENTITIES];
 
 s_tileset tilesets[MAX_TILESETS];
 int num_tilesets = 0;
@@ -1582,7 +1582,7 @@ static void prepare_map(int msx, int msy, int mvx, int mvy)
         g_ent[i].moving = 0;
     }
 
-    for (i = 0; i < MAX_ENTITIES_PER_MAP; i++)
+    for (i = 0; i < MAX_ENTITIES; i++)
     {
         if (g_ent[i].chrx == 38 && g_ent[i].active == 1)
         {
@@ -1650,7 +1650,7 @@ static void prepare_map(int msx, int msy, int mvx, int mvy)
 
     count_entities();
 
-    for (i = 0; i < MAX_ENTITIES_PER_MAP; i++)
+    for (i = 0; i < MAX_ENTITIES; i++)
     {
         g_ent[i].delayctr = 0;
     }

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -142,7 +142,7 @@ static void copy_map(int *map)
     }
 
     /*  RB: faster to do this than to check if there is an entity at every square  */
-    for (entity_index = 0; entity_index < MAX_ENTITIES_PER_MAP; entity_index++)
+    for (entity_index = 0; entity_index < MAX_ENTITIES; entity_index++)
     {
         if (g_ent[entity_index].active)
         {


### PR DESCRIPTION
Entities includes those defined in the map file *plus* the party,
hence the maximum number of entities is MAX_ENTITIES_PER_MAP +
PSIZE. There were some inconsistencies in use, but they were unlikely
to have caused any visible problems because no maps define the full
number of entities allowed.