### PR TITLE
Make a copy of the message before calling deallocate_stuff.

### DIFF
--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -1695,9 +1695,12 @@ static void prepare_map(int msx, int msy, int mvx, int mvy)
 void program_death(const char *message)
 {
     TRACE("%s\n", message);
+	char tmp[1024];
+	memset(tmp, 0, sizeof(tmp));
+	strncpy(tmp, message, sizeof(tmp) - 1);
     deallocate_stuff();
     set_gfx_mode(GFX_TEXT, 0, 0, 0, 0);
-    allegro_message("%s\n", message);
+    allegro_message("%s\n", tmp);
     exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
The reason is that program_death is often called with a message in
strbuf, which is deallocated. This causes garbage output and/or memory
faults. We need to call allegro_message only from text mode, but we
need to be in graphics mode to call deallocate_stuff.