### PR TITLE
Set local variables at the directory level for Emacs.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,10 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((c-mode
+  (comment-column . 0))
+ (emacs-lisp-mode
+  (tab-width . 4)
+  (indent-tabs-mode)))
+
+

--- a/include/bounds.h
+++ b/include/bounds.h
@@ -86,9 +86,3 @@ size_t       save_bounds(s_bound_array *, PACKFILE *);
 
 #endif  /* __BOUNDS_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/combat.h
+++ b/include/combat.h
@@ -70,9 +70,3 @@ extern struct DATAFILE *backart;        /*  hskill.c  */
 
 #endif  /* __COMBAT_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/console.h
+++ b/include/console.h
@@ -33,9 +33,3 @@ void scroll_console(const char *);
 
 #endif  /* __CONSOLE_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/credits.h
+++ b/include/credits.h
@@ -41,9 +41,3 @@ int ease(signed int);
 
 #endif  /* __CREDITS_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/disk.h
+++ b/include/disk.h
@@ -40,9 +40,3 @@ int save_s_tileset(s_tileset *, PACKFILE *);
 
 #endif  /* __DISK_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/draw.h
+++ b/include/draw.h
@@ -136,9 +136,3 @@ extern unsigned char DARKRED;
 
 #endif  /* __DRAW_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/effects.h
+++ b/include/effects.h
@@ -36,9 +36,3 @@ int is_active(int);             /*  hskill.c  */
 
 #endif  /* __EFFECTS_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/enemyc.h
+++ b/include/enemyc.h
@@ -32,9 +32,3 @@ void enemy_charmaction(size_t);    /*  combat.c, heroc.c  */
 
 #endif  /* __ENEMYC_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/entity.h
+++ b/include/entity.h
@@ -67,9 +67,3 @@ enum eCommands
 
 #endif  /* __ENTITY_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/enums.h
+++ b/include/enums.h
@@ -369,9 +369,3 @@ enum eEquipment
 #endif  /* __ENUMS_H */
 
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/eqpmenu.h
+++ b/include/eqpmenu.h
@@ -29,9 +29,3 @@ void equip_menu(unsigned int);           /*  menu.c  */
 
 #endif  /* __EQPMENU_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/eskill.h
+++ b/include/eskill.h
@@ -34,9 +34,3 @@ void combat_skill(size_t);
 
 #endif  /* __ESKILL_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/fade.h
+++ b/include/fade.h
@@ -38,9 +38,3 @@ void do_transition(eTransitionFade, int);
 
 #endif  /* __FADE_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/fighter.h
+++ b/include/fighter.h
@@ -68,9 +68,3 @@ typedef struct
 
 #endif  /* __FIGHTER_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/gettext.h
+++ b/include/gettext.h
@@ -302,9 +302,3 @@ dcnpgettext_expr(const char *domain,
 
 #endif /* _LIBGETTEXT_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/heroc.h
+++ b/include/heroc.h
@@ -56,9 +56,3 @@ int combat_spell_menu(int);     /*  hskill.c  */
 
 #endif  /* __HEROC_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/hskill.h
+++ b/include/hskill.h
@@ -30,9 +30,3 @@ int skill_use(size_t);             /*  heroc.c  */
 
 #endif  /* __HSKILL_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/intrface.h
+++ b/include/intrface.h
@@ -43,9 +43,3 @@ void lua_user_init(void);       /*  kq.c */
 
 #endif  /* __INTRFACE_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/itemdefs.h
+++ b/include/itemdefs.h
@@ -229,9 +229,3 @@
 
 #endif  /* __ITEMDEFS_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/itemmenu.h
+++ b/include/itemmenu.h
@@ -44,9 +44,3 @@ int useup_item(int);
 
 #endif  /* __ITEMMENU_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/kq.h
+++ b/include/kq.h
@@ -196,9 +196,3 @@ extern BITMAP *obj_mesh;
 
 #endif  /* __KQ_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/kqsnd.h
+++ b/include/kqsnd.h
@@ -47,9 +47,3 @@
 #define WHOOSH_WAV                       41       /* SAMP */
 #define WIND_WAV                         42       /* SAMP */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/magic.h
+++ b/include/magic.h
@@ -116,9 +116,3 @@ s_fighter status_adjust(size_t);   /*  combat.c, [he]skill.c  */
 
 #endif  /* __MAGIC_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/markers.h
+++ b/include/markers.h
@@ -74,9 +74,3 @@ size_t save_markers(s_marker_array *, PACKFILE *);
 
 #endif  /* __MARKERS_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/masmenu.h
+++ b/include/masmenu.h
@@ -32,9 +32,3 @@ extern int close_menu;          /*  menu.c  */
 
 #endif  /* __MASMENU_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/menu.h
+++ b/include/menu.h
@@ -68,9 +68,3 @@ typedef struct info_list
 
 #endif  /* __MENU_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/movement.h
+++ b/include/movement.h
@@ -29,9 +29,3 @@ int find_path(size_t, unsigned int, unsigned int, unsigned int, unsigned int, ch
 
 #endif  /* __MOVEMENT_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/mpcx.h
+++ b/include/mpcx.h
@@ -37,9 +37,3 @@
 #define VILLAGE_PCX                      31       /* BMP  */
 #define X_KQ_PAL                         32       /* PAL  */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/music.h
+++ b/include/music.h
@@ -44,9 +44,3 @@ void stop_music(void);
 
 #endif  /* __MUSIC_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/platform.h
+++ b/include/platform.h
@@ -62,9 +62,3 @@ const char *get_resource_file_path(const char *, const char *, const char *);
 
 #endif  /* __PLATFORM_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/res.h
+++ b/include/res.h
@@ -184,9 +184,3 @@ extern s_encounter battles[NUM_BATTLES];    /*  only in combat.c  */
 
 #endif  /* __RES_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/selector.h
+++ b/include/selector.h
@@ -40,9 +40,3 @@ void party_newlead(void);                   /*  selector.c, menu.c  */
 
 #endif  /* __SELECTOR_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/setup.h
+++ b/include/setup.h
@@ -100,9 +100,3 @@ const char *kq_keyname(int);
 
 #endif  /* __SETUP_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/sgame.h
+++ b/include/sgame.h
@@ -37,9 +37,3 @@ int system_menu(void);          /*  kq.c  */
 
 #endif  /* __SGAME_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/shopmenu.h
+++ b/include/shopmenu.h
@@ -51,9 +51,3 @@ extern unsigned short shop_time[NUMSHOPS];
 
 #endif  /* __SHOPMENU_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/skills.h
+++ b/include/skills.h
@@ -30,9 +30,3 @@ void infusion(int, int);        /*  hskill.c  */
 
 #endif  /* __SKILLS_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/ssprites.h
+++ b/include/ssprites.h
@@ -54,9 +54,3 @@
 #define WHITE_PCX                        48     /* BMP  */
 #define XSURGE_PCX                       49     /* BMP  */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/structs.h
+++ b/include/structs.h
@@ -218,9 +218,3 @@ typedef struct
 
 #endif  /* __STRUCTS_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/include/timing.h
+++ b/include/timing.h
@@ -30,9 +30,3 @@ int limit_frame_rate(int fps);
 
 #endif  /* __TIMING_H */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/bounds.cpp
+++ b/src/bounds.cpp
@@ -304,9 +304,3 @@ void set_bounds(
     which_bound->btile = btile;
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1805,9 +1805,3 @@ static void snap_togrid(void)
     }
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -255,9 +255,3 @@ void run_console(void)
     while (benter);
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/credits.cpp
+++ b/src/credits.cpp
@@ -202,9 +202,3 @@ int ease(signed int x)
     }
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/disk.cpp
+++ b/src/disk.cpp
@@ -320,9 +320,3 @@ int save_s_tileset(s_tileset *s, PACKFILE *f)
     return 0;
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -2227,9 +2227,3 @@ void porttext_ex(int fmt, int who, const char *s)
     }
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -617,9 +617,3 @@ int is_active(int guy)
     return (fighter[guy].sts[S_DEAD] == deadeffect ? 1 : 0);
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/enemyc.cpp
+++ b/src/enemyc.cpp
@@ -1143,9 +1143,3 @@ void unload_enemies(void)
     }
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1157,9 +1157,3 @@ static void wander(t_entity target_entity)
     }
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/eqpmenu.cpp
+++ b/src/eqpmenu.cpp
@@ -819,9 +819,3 @@ static void optimize_equip(int c)
     play_effect(SND_EQUIP, 128);
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/eskill.cpp
+++ b/src/eskill.cpp
@@ -337,9 +337,3 @@ void combat_skill(size_t fighter_index)
     }
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/fade.cpp
+++ b/src/fade.cpp
@@ -130,9 +130,3 @@ void do_transition(eTransitionFade type, int param)
     }
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/heroc.cpp
+++ b/src/heroc.cpp
@@ -1366,9 +1366,3 @@ static void hero_run(void)
     combatend = 2;
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/hskill.cpp
+++ b/src/hskill.cpp
@@ -908,9 +908,3 @@ int skill_use(size_t attack_fighter_index)
     return 1;
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/intrface.cpp
+++ b/src/intrface.cpp
@@ -5002,9 +5002,3 @@ static void set_shadow(int x, int y, int value)
     s_seg[y * g_map.xsize + x] = value;
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/itemmenu.cpp
+++ b/src/itemmenu.cpp
@@ -949,9 +949,3 @@ int useup_item(int item_id)
     return 0;
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -2378,9 +2378,3 @@ void zone_check(void)
  * The names given are the base names of the maps/lua scripts
  */
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1831,9 +1831,3 @@ s_fighter status_adjust(size_t fighter_index)
     return tf;
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/markers.cpp
+++ b/src/markers.cpp
@@ -165,9 +165,3 @@ size_t save_markers(s_marker_array *marray, PACKFILE *pf)
     return 0;
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/masmenu.cpp
+++ b/src/masmenu.cpp
@@ -497,9 +497,3 @@ static int need_spell(size_t target_fighter_index, size_t spell_number)
     return 1;
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -964,9 +964,3 @@ void update_equipstats(void)
 }
 
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -331,9 +331,3 @@ static int search_paths(unsigned int entity_id, int *map, unsigned int step,
     return (result);
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -236,9 +236,3 @@ void resume_music(void)
     }
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/music_dumb.cpp
+++ b/src/music_dumb.cpp
@@ -223,9 +223,3 @@ void stop_music(void)
     }
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/res.cpp
+++ b/src/res.cpp
@@ -1620,9 +1620,3 @@ s_encounter battles[NUM_BATTLES] =
 
 // *INDENT-ON*
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/selector.cpp
+++ b/src/selector.cpp
@@ -1110,9 +1110,3 @@ int select_player(void)
     return ptr;
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -1130,9 +1130,3 @@ void sound_init(void)
     }
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/sgame.cpp
+++ b/src/sgame.cpp
@@ -1791,9 +1791,3 @@ int system_menu(void)
     return 0;
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/shopmenu.cpp
+++ b/src/shopmenu.cpp
@@ -951,9 +951,3 @@ int shop(int shop_num)
     return 0;
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/timing.cpp
+++ b/src/timing.cpp
@@ -217,9 +217,3 @@ int limit_frame_rate(int fps)
 
 #endif  // HAVE_SYS_SELECT_H
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */

--- a/src/unix.cpp
+++ b/src/unix.cpp
@@ -183,9 +183,3 @@ const char *kqres(enum eDirectories dir, const char *file)
     }
 }
 
-/* Local Variables:     */
-/* mode: c              */
-/* comment-column: 0    */
-/* indent-tabs-mode nil */
-/* tab-width: 4         */
-/* End:                 */


### PR DESCRIPTION
There was a bug in the file-local variable specification; a missing
colon after indent-tabs-mode. This meant that emacs always showed an
error message when loading any file. Since these file-local variables
are the same for all source files it makes sense to set them for all
in one place (affects all files opened in C-mode.) Unfortunately this
has meant touching every source file in the project.