### PR TITLE
Add support for compilation with old versions of g++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,13 @@ set(mapdiff_SRCS
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/maps")
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.1")
+        set(STD_VERSION c++1y)
+    endif()
+else()
+    set(STD_VERSION c++14)
+endif()
 # DEBUGMODE lets players alter options in the ESC->Config menu (including seeing obstacles and zones)
 #add_definitions(-DDEBUGMODE)
 
@@ -103,7 +110,7 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURC
 #add_definitions(-DKQ_CHEATS)
 
 #set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-O0 -g -ggdb3 -DDEBUG -DKQ_CHEATS -Wall -Wextra -Wpedantic -std=c++14")
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-O0 -g -ggdb3 -Wall -Wextra -Wpedantic -std=c++14")
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-O0 -g -ggdb3 -Wall -Wextra -Wpedantic -std=${STD_VERSION}")
 #set(ALLEGRO_LIBRARY "-lalleg")
 #set(DUMB_LIBRARY "-laldmb -ldumb")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
GCC versions 4.9 and earlier don't have support for `c++14` as the language standard option, they use `c++1y` instead. GCC 5.1 and newer deprecate that in favor of `c++14`. See these links:

http://stackoverflow.com/questions/31965413/compile-c14-code-with-g
https://gcc.gnu.org/onlinedocs/gcc-4.9.3/gcc/C-Dialect-Options.html#C-Dialect-Options
https://gcc.gnu.org/onlinedocs/gcc-5.1.0/gcc/C-Dialect-Options.html#C-Dialect-Options