### PR TITLE
Support for compilation with new versions of g++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 
 project(kq-fork)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,15 +95,7 @@ set(mapdiff_SRCS
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/maps")
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.1")
-        set(STD_VERSION c++1y)
-    else()
-    	set(STD_VERSION c++14)
-    endif()
-else()
-    set(STD_VERSION c++14)
-endif()
+set(CMAKE_CXX_STANDARD 14)
 # DEBUGMODE lets players alter options in the ESC->Config menu (including seeing obstacles and zones)
 #add_definitions(-DDEBUGMODE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURC
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.1")
         set(STD_VERSION c++1y)
+    else()
+    	set(STD_VERSION c++14)
     endif()
 else()
     set(STD_VERSION c++14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ set(CMAKE_CXX_STANDARD 14)
 #add_definitions(-DKQ_CHEATS)
 
 #set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-O0 -g -ggdb3 -DDEBUG -DKQ_CHEATS -Wall -Wextra -Wpedantic -std=c++14")
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-O0 -g -ggdb3 -Wall -Wextra -Wpedantic -std=${STD_VERSION}")
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-O0 -g -ggdb3 -Wall -Wextra -Wpedantic")
 #set(ALLEGRO_LIBRARY "-lalleg")
 #set(DUMB_LIBRARY "-laldmb -ldumb")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
The commit that added support for older versions of g++ broke compatibility with new versions. This should fix it.