### PR TITLE
Don't clobber the std::string parts of s_map with memset.

### DIFF
--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -1863,7 +1863,6 @@ static void startup(void)
 
     map_seg = b_seg = f_seg = NULL;
     s_seg = z_seg = o_seg = NULL;
-    memset(&g_map, 0, sizeof(s_map));
 
     allocate_stuff();
     install_keyboard();


### PR DESCRIPTION
This causes a segfault on some versions of libstdc++ (GNU versions prior
to 5.0, maybe others)

It's not necessary to initialise g_map because it's a global and therefore
initialised automatically at start-up.

Fixes #47 