### PR TITLE
Tweak to prevent warnings due to lack of variable sized arrays in C++

### DIFF
--- a/include/gettext.h
+++ b/include/gettext.h
@@ -191,7 +191,7 @@ npgettext_aux(const char *domain,
 #include <string.h>
 
 #if (((__GNUC__ >= 3 || __GNUG__ >= 2) && !defined __STRICT_ANSI__) \
-     /* || __STDC_VERSION__ >= 199901L */ )
+     && !defined __cplusplus )
 # define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 1
 #else
 # define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 0


### PR DESCRIPTION
See https://lists.gnu.org/archive/html/bug-gnulib/2010-11/msg00017.html