### PR TITLE
Fix freed memory reference in music.

### DIFF
--- a/src/music.cpp
+++ b/src/music.cpp
@@ -108,7 +108,8 @@ void KMusic::poll_music(void) {
  */
 void KMusic::play_music(const std::string &music_name, long position) {
   if (is_sound != 0) {
-    const char *filename = kqres(MUSIC_DIR, music_name).c_str();
+    const std::string fstr = kqres(MUSIC_DIR, music_name);
+    const char *filename = fstr.c_str();
 
     stop_music();
     if (exists(filename)) {


### PR DESCRIPTION
Extend the lifetime of the std::string backing a repeatedly used cstring
to the block in which it is used.


Music worked for me (TM) in classic r910, with minor modifications to
pulseaudio configuration, but was broken in the latest master.

After bisecting to find where it broke (why are there so many broken
intermediary commits? Repeat backporting is not fun T_T), I discovered the
culprit was commit c345d35b4e9544f1bdf7d02bd3e8f362a6900e66.

When changing the cstring logic to std::string, KMusic::play_music just took
c_str from a temporary string, which immediately went out of scope and was
freed. This freed pointer is then used repeatedly throughout the function.
This presumably happened to continue to point to the value that it was expected
to have, just enough to pass testing at the time.