### PR TITLE
Fix crash on game continue: initialise KQRandom

### DIFF
--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -1160,7 +1160,7 @@ int main(int argc, const char *argv[])
 
 	Game.startup();
 	game_on = 1;
-	kqrandom = nullptr;
+	kqrandom = new KQRandom();
 	/* While KQ is running (playing or at startup menu) */
 	while (game_on)
 	{


### PR DESCRIPTION
Previously, selecting to continue a game (without having previously started a
game) from the main menu would cause a crash in disk.cpp at
kqrandom->kq_set_random_state(state); with the following telltale frame in GDB:
  #5  KQRandom::kq_set_random_state (this=0x0, new_state="1016260626") at /home/user/repo/kq-fork/src/random.cpp:53
as previously kqrandom was only ever initialised when a new game was starting.