### PR TITLE
Bug: settings were not stored properly after being changed

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -32,7 +32,7 @@ int KConfig::get_config_int(const char* section, const char* key, int defl)
 void KConfig::set_config_int(const char* section, const char* key, int value)
 {
     auto& data = section ? current.sections[section] : current.unnamed;
-    data.emplace(key, value);
+    data[key] = value;
     current.dirty = true;
 }
 


### PR DESCRIPTION
A misunderstanding about `std::map::emplace` meant that if you changed a setting in the game, it wouldn't be written out to the config file for next time.