### PR TITLE
Add .vscode/ to .gitignore, with a few exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,20 @@ maps/build/
 Debug/
 Release/
 
+# Visual Studio Code (see https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore)
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
 # Auto-generated files
 ABOUT-NLS
 aclocal.m4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "C_Cpp.autoAddFileAssociations": true,
+    "C_Cpp.default.cppStandard": "c++17",
+    "C_Cpp.default.cStandard": "c17",
+    "files.associations": {
+    }
+}


### PR DESCRIPTION
According to [VisualStudioCode.gitignore](/github/gitignore/blob/main/Global/VisualStudioCode.gitignore), a few files should be shared across teams.

However...

That stupid `"files.associations"` keeps filling up when you follow a system-installed header (like `#include <string>`). So this PR holds the other useful settings, but leaves all those entries out of it. There are ongoing discussions for vscode to move that to another file, but until then...