### PR TITLE
Move sound processing/handling into a common class

### DIFF
--- a/include/kq.h
+++ b/include/kq.h
@@ -178,7 +178,7 @@ class KGame
      *
      * \param   msg String to add to log file
      */
-    void klog(const char* msg);
+    void klog(const std::string& msg);
 
     /*! \brief Pause for a time
      *

--- a/include/kq.h
+++ b/include/kq.h
@@ -451,7 +451,8 @@ extern int gsvol, gmvol;
 /*! Number of entities (or enemies?) */
 extern uint32_t number_of_entities;
 extern ePIDX pidx[MAXCHRS];
-extern uint8_t autoparty, alldead, is_sound, deadeffect, use_sstone, sound_avail;
+extern uint8_t autoparty, alldead, deadeffect, use_sstone;
+extern uint8_t sound_initialized_and_ready, sound_avail;
 extern bool bDoesViewportFollowPlayer;
 extern const uint8_t kq_version;
 extern uint8_t hold_fade, cansave, skip_intro, wait_retrace, windowed, cpu_usage;

--- a/include/kq.h
+++ b/include/kq.h
@@ -452,7 +452,6 @@ extern int gsvol, gmvol;
 extern uint32_t number_of_entities;
 extern ePIDX pidx[MAXCHRS];
 extern uint8_t autoparty, alldead, deadeffect, use_sstone;
-extern uint8_t sound_initialized_and_ready, sound_avail;
 extern bool bDoesViewportFollowPlayer;
 extern const uint8_t kq_version;
 extern uint8_t hold_fade, cansave, skip_intro, wait_retrace, windowed, cpu_usage;

--- a/include/setup.h
+++ b/include/setup.h
@@ -21,21 +21,25 @@
 
 #pragma once
 
+class KAudio
+{
+    public:
+        enum eSound
+        {
+            SND_MENU = 0,
+            SND_CLICK = 1,
+            SND_BAD = 2,
+            SND_ITEM = 3,
+            SND_EQUIP = 4,
+            SND_UNEQUIP = 5,
+            SND_MONEY = 6,
+            SND_TWINKLE = 7,
+            SND_EXPLODE = 42,
+            MAX_SAMPLES // always last
+        };
+};
+
 /*! \file */
-
-/*  RB IDEA: We can use the COUNT definition of the new datafile  */
-/*           dump rather than hardcoding the value here.          */
-#define MAX_SAMPLES 43
-
-#define SND_MENU 0
-#define SND_CLICK 1
-#define SND_BAD 2
-#define SND_ITEM 3
-#define SND_EQUIP 4
-#define SND_UNEQUIP 5
-#define SND_MONEY 6
-#define SND_TWINKLE 7
-#define SND_EXPLODE 42
 
 /*  This is in addition to setup.c:  */
 void parse_setup(void);

--- a/include/setup.h
+++ b/include/setup.h
@@ -37,6 +37,17 @@ class KAudio
             SND_EXPLODE = 42,
             MAX_SAMPLES // always last
         };
+
+        enum eSoundSystem
+        {
+            NotInitialized,
+            Initialize,
+            Ready
+        };
+
+    public:
+        ~KAudio() = default;
+        KAudio();
 };
 
 /*! \file */

--- a/include/setup.h
+++ b/include/setup.h
@@ -48,11 +48,13 @@ class KAudio
     public:
         ~KAudio() = default;
         KAudio();
+
+        eSoundSystem sound_initialized_and_ready;
+        bool sound_system_avail;
 };
 
-/*! \file */
+extern KAudio Audio;
 
-/*  This is in addition to setup.c:  */
 void parse_setup(void);
 void config_menu(void);
 void show_help(void);

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -1188,7 +1188,7 @@ int KDraw::prompt(int who, int numopt, eBubbleStyle bstyle, const char* sp1, con
             {
                 --ptr;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.down())
         {
@@ -1196,7 +1196,7 @@ int KDraw::prompt(int who, int numopt, eBubbleStyle bstyle, const char* sp1, con
             {
                 ++ptr;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -1296,24 +1296,24 @@ int KDraw::prompt_ex(int who, const char* ptext, const char* opt[], int n_opt)
 
                 if (PlayerInput.up() && curopt > 0)
                 {
-                    play_effect(SND_CLICK, 128);
+                    play_effect(KAudio::eSound::SND_CLICK, 128);
                     --curopt;
                 }
                 else if (PlayerInput.down() && curopt < (n_opt - 1))
                 {
-                    play_effect(SND_CLICK, 128);
+                    play_effect(KAudio::eSound::SND_CLICK, 128);
                     ++curopt;
                 }
                 else if (PlayerInput.balt())
                 {
                     /* Selected an option */
-                    play_effect(SND_CLICK, 128);
+                    play_effect(KAudio::eSound::SND_CLICK, 128);
                     running = 0;
                 }
                 else if (PlayerInput.bctrl())
                 {
                     /* Just go "ow!" */
-                    play_effect(SND_BAD, 128);
+                    play_effect(KAudio::eSound::SND_BAD, 128);
                 }
 
                 /* Adjust top position so that the current option is always shown */

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -258,7 +258,7 @@ void KEffects::draw_attacksprite(size_t target_fighter_index, int multiple_targe
     {
         if (Combat.GetHealthAdjust(start_fighter_index) == MISS)
         {
-            play_effect(Audio::eSound::SND_MENU, 128);
+            play_effect(KAudio::eSound::SND_MENU, 128);
         }
         else
         {

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -258,7 +258,7 @@ void KEffects::draw_attacksprite(size_t target_fighter_index, int multiple_targe
     {
         if (Combat.GetHealthAdjust(start_fighter_index) == MISS)
         {
-            play_effect(SND_MENU, 128);
+            play_effect(Audio::eSound::SND_MENU, 128);
         }
         else
         {

--- a/src/eqpmenu.cpp
+++ b/src/eqpmenu.cpp
@@ -134,7 +134,7 @@ static void choose_equipment(int c, int slot)
         if (tot == 0)
         {
             draw_equippreview(c, -1, 0);
-            play_effect(SND_BAD, 128);
+            play_effect(Audio::eSound::SND_BAD, 128);
             return;
         }
         draw_equippreview(c, slot, g_inv[t_inv[pptr + yptr]].item);
@@ -167,7 +167,7 @@ static void choose_equipment(int c, int slot)
                     yptr++;
                 }
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.up())
         {
@@ -183,18 +183,18 @@ static void choose_equipment(int c, int slot)
             {
                 yptr--;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
             if (equip(pidx[c], t_inv[pptr + yptr], 0) == 1)
             {
-                play_effect(SND_EQUIP, 128);
+                play_effect(Audio::eSound::SND_EQUIP, 128);
                 stop = 1;
             }
             else
             {
-                play_effect(SND_BAD, 128);
+                play_effect(Audio::eSound::SND_BAD, 128);
             }
         }
         if (PlayerInput.bctrl())
@@ -537,7 +537,7 @@ void equip_menu(uint32_t c)
     int a, b, d;
 
     eqp_act = 0;
-    play_effect(SND_MENU, 128);
+    play_effect(Audio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -576,7 +576,7 @@ void equip_menu(uint32_t c)
                 {
                     eqp_act = 3;
                 }
-                play_effect(SND_CLICK, 128);
+                play_effect(Audio::eSound::SND_CLICK, 128);
             }
             if (PlayerInput.right())
             {
@@ -585,7 +585,7 @@ void equip_menu(uint32_t c)
                 {
                     eqp_act = 0;
                 }
-                play_effect(SND_CLICK, 128);
+                play_effect(Audio::eSound::SND_CLICK, 128);
             }
         }
         else
@@ -597,7 +597,7 @@ void equip_menu(uint32_t c)
                 {
                     yptr = 0;
                 }
-                play_effect(SND_CLICK, 128);
+                play_effect(Audio::eSound::SND_CLICK, 128);
             }
             if (PlayerInput.up())
             {
@@ -606,7 +606,7 @@ void equip_menu(uint32_t c)
                 {
                     yptr = 5;
                 }
-                play_effect(SND_CLICK, 128);
+                play_effect(Audio::eSound::SND_CLICK, 128);
             }
         }
         if (PlayerInput.balt())
@@ -636,11 +636,11 @@ void equip_menu(uint32_t c)
                     }
                     if (b == d)
                     {
-                        play_effect(SND_UNEQUIP, 128);
+                        play_effect(Audio::eSound::SND_UNEQUIP, 128);
                     }
                     else
                     {
-                        play_effect(SND_BAD, 128);
+                        play_effect(Audio::eSound::SND_BAD, 128);
                     }
                 }
             }
@@ -656,11 +656,11 @@ void equip_menu(uint32_t c)
                     {
                         if (deequip(c, yptr) == 1)
                         {
-                            play_effect(SND_UNEQUIP, 128);
+                            play_effect(Audio::eSound::SND_UNEQUIP, 128);
                         }
                         else
                         {
-                            play_effect(SND_BAD, 128);
+                            play_effect(Audio::eSound::SND_BAD, 128);
                         }
                     }
                 }
@@ -773,5 +773,5 @@ static void optimize_equip(int c)
             return;
         }
     }
-    play_effect(SND_EQUIP, 128);
+    play_effect(Audio::eSound::SND_EQUIP, 128);
 }

--- a/src/eqpmenu.cpp
+++ b/src/eqpmenu.cpp
@@ -134,7 +134,7 @@ static void choose_equipment(int c, int slot)
         if (tot == 0)
         {
             draw_equippreview(c, -1, 0);
-            play_effect(Audio::eSound::SND_BAD, 128);
+            play_effect(KAudio::eSound::SND_BAD, 128);
             return;
         }
         draw_equippreview(c, slot, g_inv[t_inv[pptr + yptr]].item);
@@ -167,7 +167,7 @@ static void choose_equipment(int c, int slot)
                     yptr++;
                 }
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.up())
         {
@@ -183,18 +183,18 @@ static void choose_equipment(int c, int slot)
             {
                 yptr--;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
             if (equip(pidx[c], t_inv[pptr + yptr], 0) == 1)
             {
-                play_effect(Audio::eSound::SND_EQUIP, 128);
+                play_effect(KAudio::eSound::SND_EQUIP, 128);
                 stop = 1;
             }
             else
             {
-                play_effect(Audio::eSound::SND_BAD, 128);
+                play_effect(KAudio::eSound::SND_BAD, 128);
             }
         }
         if (PlayerInput.bctrl())
@@ -537,7 +537,7 @@ void equip_menu(uint32_t c)
     int a, b, d;
 
     eqp_act = 0;
-    play_effect(Audio::eSound::SND_MENU, 128);
+    play_effect(KAudio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -576,7 +576,7 @@ void equip_menu(uint32_t c)
                 {
                     eqp_act = 3;
                 }
-                play_effect(Audio::eSound::SND_CLICK, 128);
+                play_effect(KAudio::eSound::SND_CLICK, 128);
             }
             if (PlayerInput.right())
             {
@@ -585,7 +585,7 @@ void equip_menu(uint32_t c)
                 {
                     eqp_act = 0;
                 }
-                play_effect(Audio::eSound::SND_CLICK, 128);
+                play_effect(KAudio::eSound::SND_CLICK, 128);
             }
         }
         else
@@ -597,7 +597,7 @@ void equip_menu(uint32_t c)
                 {
                     yptr = 0;
                 }
-                play_effect(Audio::eSound::SND_CLICK, 128);
+                play_effect(KAudio::eSound::SND_CLICK, 128);
             }
             if (PlayerInput.up())
             {
@@ -606,7 +606,7 @@ void equip_menu(uint32_t c)
                 {
                     yptr = 5;
                 }
-                play_effect(Audio::eSound::SND_CLICK, 128);
+                play_effect(KAudio::eSound::SND_CLICK, 128);
             }
         }
         if (PlayerInput.balt())
@@ -636,11 +636,11 @@ void equip_menu(uint32_t c)
                     }
                     if (b == d)
                     {
-                        play_effect(Audio::eSound::SND_UNEQUIP, 128);
+                        play_effect(KAudio::eSound::SND_UNEQUIP, 128);
                     }
                     else
                     {
-                        play_effect(Audio::eSound::SND_BAD, 128);
+                        play_effect(KAudio::eSound::SND_BAD, 128);
                     }
                 }
             }
@@ -656,11 +656,11 @@ void equip_menu(uint32_t c)
                     {
                         if (deequip(c, yptr) == 1)
                         {
-                            play_effect(Audio::eSound::SND_UNEQUIP, 128);
+                            play_effect(KAudio::eSound::SND_UNEQUIP, 128);
                         }
                         else
                         {
-                            play_effect(Audio::eSound::SND_BAD, 128);
+                            play_effect(KAudio::eSound::SND_BAD, 128);
                         }
                     }
                 }
@@ -773,5 +773,5 @@ static void optimize_equip(int c)
             return;
         }
     }
-    play_effect(Audio::eSound::SND_EQUIP, 128);
+    play_effect(KAudio::eSound::SND_EQUIP, 128);
 }

--- a/src/heroc.cpp
+++ b/src/heroc.cpp
@@ -407,7 +407,7 @@ static int combat_item_menu(int whom)
             {
                 ptr = 15;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.down())
         {
@@ -416,7 +416,7 @@ static int combat_item_menu(int whom)
             {
                 ptr = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.left())
         {
@@ -425,7 +425,7 @@ static int combat_item_menu(int whom)
             {
                 pptr = 3;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.right())
         {
@@ -434,7 +434,7 @@ static int combat_item_menu(int whom)
             {
                 pptr = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -508,7 +508,7 @@ int combat_spell_menu(int c)
     int ptr = 0, pgno = 0, stop = 0;
 
     fullblit(double_buffer, back);
-    play_effect(SND_MENU, 128);
+    play_effect(KAudio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -524,7 +524,7 @@ int combat_spell_menu(int c)
             {
                 ptr = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.up())
         {
@@ -533,7 +533,7 @@ int combat_spell_menu(int c)
             {
                 ptr = 11;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.right())
         {
@@ -542,7 +542,7 @@ int combat_spell_menu(int c)
             {
                 pgno = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.left())
         {
@@ -551,7 +551,7 @@ int combat_spell_menu(int c)
             {
                 pgno = 4;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -819,7 +819,7 @@ void hero_choose_action(size_t fighter_index)
             {
                 ptr = my - 1;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.down())
         {
@@ -831,7 +831,7 @@ void hero_choose_action(size_t fighter_index)
             {
                 ptr = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.left())
         {
@@ -1062,7 +1062,7 @@ static int hero_invoke(int whom)
             {
                 ptr = 5;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.down())
         {
@@ -1071,7 +1071,7 @@ static int hero_invoke(int whom)
             {
                 ptr = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -1084,7 +1084,7 @@ static int hero_invoke(int whom)
             }
             else
             {
-                play_effect(SND_BAD, 128);
+                play_effect(KAudio::eSound::SND_BAD, 128);
             }
         }
         if (PlayerInput.bctrl())

--- a/src/hskill.cpp
+++ b/src/hskill.cpp
@@ -779,7 +779,7 @@ int skill_use(size_t attack_fighter_index)
         Combat.battle_render(0, attack_fighter_index + 1, 0);
         Draw.blit2screen();
         kq_wait(100);
-        play_effect(SND_MENU, 128);
+        play_effect(KAudio::eSound::SND_MENU, 128);
         kq_wait(500);
         display_attack_string = 0;
         Combat.battle_render(attack_fighter_index, attack_fighter_index, 0);

--- a/src/intrface.cpp
+++ b/src/intrface.cpp
@@ -1489,7 +1489,7 @@ static int KQ_chest(lua_State* L)
     {
         Game.AddGold(item_quantity);
         sprintf(strbuf, _("Found %d gp!"), item_quantity);
-        play_effect(SND_MONEY, 128);
+        play_effect(KAudio::eSound::SND_MONEY, 128);
         Draw.message(strbuf, 255, 0);
         if (treasure_index > -1)
         {
@@ -1537,7 +1537,7 @@ static int KQ_chest(lua_State* L)
         {
             sprintf(strbuf, _("%s ^%d procured!"), items[inventory_index].name, (int)item_quantity);
         }
-        play_effect(SND_UNEQUIP, 128);
+        play_effect(KAudio::eSound::SND_UNEQUIP, 128);
         Draw.message(strbuf, items[inventory_index].icon, 0);
         if (treasure_index > -1)
         {

--- a/src/itemmenu.cpp
+++ b/src/itemmenu.cpp
@@ -64,7 +64,7 @@ void camp_item_menu(void)
     int stop = 0, ptr = 0, pptr = 0, sel = 0;
 
     item_act = 0;
-    play_effect(SND_MENU, 128);
+    play_effect(Audio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -82,7 +82,7 @@ void camp_item_menu(void)
                 {
                     ptr = 0;
                 }
-                play_effect(SND_CLICK, 128);
+                play_effect(Audio::eSound::SND_CLICK, 128);
             }
             if (PlayerInput.up())
             {
@@ -91,7 +91,7 @@ void camp_item_menu(void)
                 {
                     ptr = 15;
                 }
-                play_effect(SND_CLICK, 128);
+                play_effect(Audio::eSound::SND_CLICK, 128);
             }
         }
         if (PlayerInput.right())
@@ -114,7 +114,7 @@ void camp_item_menu(void)
                     item_act = 0;
                 }
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.left())
         {
@@ -136,7 +136,7 @@ void camp_item_menu(void)
                     item_act = 2;
                 }
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -238,14 +238,14 @@ static void camp_item_targetting(int pp)
             eItemEffectResult z = item_effects(0, tg, t1);
             if (z == ITEM_EFFECT_INEFFECTIVE)
             {
-                play_effect(SND_BAD, 128);
+                play_effect(Audio::eSound::SND_BAD, 128);
             }
             else
             {
                 kmenu.revert_equipstats();
                 if (z == ITEM_EFFECT_SUCCESS_SINGLE)
                 {
-                    play_effect(SND_ITEM, 128);
+                    play_effect(Audio::eSound::SND_ITEM, 128);
                     select_any_player(TGT_NONE, 0, "");
                 }
                 if (items[t1].use != USE_ANY_INF && items[t1].use != USE_CAMP_INF)
@@ -691,7 +691,7 @@ eItemEffectResult item_effects(size_t attack_fighter_index, size_t fighter_index
         }
         z = items[ti].bst; // eAttribute
         party[pidx[fighter_index]].stats[z] += kqrandom->random_range_exclusive(1, 4) * 100;
-        play_effect(SND_TWINKLE, 128);
+        play_effect(Audio::eSound::SND_TWINKLE, 128);
         switch (z)
         {
         case 0:
@@ -749,7 +749,7 @@ eItemEffectResult item_effects(size_t attack_fighter_index, size_t fighter_index
             }
         }
         sprintf(strbuf, _("%s learned!"), magic[tmp].name);
-        play_effect(SND_TWINKLE, 128);
+        play_effect(Audio::eSound::SND_TWINKLE, 128);
         Draw.message(strbuf, magic[tmp].icon, 0);
         return ITEM_EFFECT_SUCCESS_MULTIPLE;
     }

--- a/src/itemmenu.cpp
+++ b/src/itemmenu.cpp
@@ -64,7 +64,7 @@ void camp_item_menu(void)
     int stop = 0, ptr = 0, pptr = 0, sel = 0;
 
     item_act = 0;
-    play_effect(Audio::eSound::SND_MENU, 128);
+    play_effect(KAudio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -82,7 +82,7 @@ void camp_item_menu(void)
                 {
                     ptr = 0;
                 }
-                play_effect(Audio::eSound::SND_CLICK, 128);
+                play_effect(KAudio::eSound::SND_CLICK, 128);
             }
             if (PlayerInput.up())
             {
@@ -91,7 +91,7 @@ void camp_item_menu(void)
                 {
                     ptr = 15;
                 }
-                play_effect(Audio::eSound::SND_CLICK, 128);
+                play_effect(KAudio::eSound::SND_CLICK, 128);
             }
         }
         if (PlayerInput.right())
@@ -114,7 +114,7 @@ void camp_item_menu(void)
                     item_act = 0;
                 }
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.left())
         {
@@ -136,7 +136,7 @@ void camp_item_menu(void)
                     item_act = 2;
                 }
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -238,14 +238,14 @@ static void camp_item_targetting(int pp)
             eItemEffectResult z = item_effects(0, tg, t1);
             if (z == ITEM_EFFECT_INEFFECTIVE)
             {
-                play_effect(Audio::eSound::SND_BAD, 128);
+                play_effect(KAudio::eSound::SND_BAD, 128);
             }
             else
             {
                 kmenu.revert_equipstats();
                 if (z == ITEM_EFFECT_SUCCESS_SINGLE)
                 {
-                    play_effect(Audio::eSound::SND_ITEM, 128);
+                    play_effect(KAudio::eSound::SND_ITEM, 128);
                     select_any_player(TGT_NONE, 0, "");
                 }
                 if (items[t1].use != USE_ANY_INF && items[t1].use != USE_CAMP_INF)
@@ -691,7 +691,7 @@ eItemEffectResult item_effects(size_t attack_fighter_index, size_t fighter_index
         }
         z = items[ti].bst; // eAttribute
         party[pidx[fighter_index]].stats[z] += kqrandom->random_range_exclusive(1, 4) * 100;
-        play_effect(Audio::eSound::SND_TWINKLE, 128);
+        play_effect(KAudio::eSound::SND_TWINKLE, 128);
         switch (z)
         {
         case 0:
@@ -749,7 +749,7 @@ eItemEffectResult item_effects(size_t attack_fighter_index, size_t fighter_index
             }
         }
         sprintf(strbuf, _("%s learned!"), magic[tmp].name);
-        play_effect(Audio::eSound::SND_TWINKLE, 128);
+        play_effect(KAudio::eSound::SND_TWINKLE, 128);
         Draw.message(strbuf, magic[tmp].icon, 0);
         return ITEM_EFFECT_SUCCESS_MULTIPLE;
     }

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -867,9 +867,9 @@ size_t KGame::in_party(ePIDX pn)
     return MAXCHRS;
 }
 
-void KGame::klog(const char* msg)
+void KGame::klog(const std::string& msg)
 {
-    TRACE("%s\n", msg);
+    TRACE("%s\n", msg.c_str());
 }
 
 void KGame::kwait(int dtime)

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -127,7 +127,7 @@ uint8_t autoparty = 0;
 uint8_t alldead = 0;
 
 /*! Is sound activated/available? */
-uint8_t is_sound = 1, sound_avail;
+uint8_t sound_initialized_and_ready = KAudio::eSoundSystem::Initialize, sound_avail;
 
 /*! Makes is_active() return TRUE even if the character is dead */
 uint8_t deadeffect = 0;
@@ -807,7 +807,7 @@ void KGame::deallocate_stuff(void)
         free(strbuf);
     }
 
-    if (is_sound)
+    if (sound_initialized_and_ready != KAudio::eSoundSystem::NotInitialized)
     {
         Music.shutdown_music();
         Music.free_samples();

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -126,9 +126,6 @@ uint8_t autoparty = 0;
 /*! Are all heroes dead? */
 uint8_t alldead = 0;
 
-/*! Is sound activated/available? */
-uint8_t sound_initialized_and_ready = KAudio::eSoundSystem::Initialize, sound_avail;
-
 /*! Makes is_active() return TRUE even if the character is dead */
 uint8_t deadeffect = 0;
 
@@ -807,7 +804,7 @@ void KGame::deallocate_stuff(void)
         free(strbuf);
     }
 
-    if (sound_initialized_and_ready != KAudio::eSoundSystem::NotInitialized)
+    if (Audio.sound_initialized_and_ready != KAudio::eSoundSystem::NotInitialized)
     {
         Music.shutdown_music();
         Music.free_samples();
@@ -1265,8 +1262,8 @@ void KGame::startup(void)
 
     start_timer(KQ_TICKS);
 
-    sound_avail = Mix_Init(MIX_INIT_MOD) != 0;
-    if (!sound_avail)
+    Audio.sound_system_avail = Mix_Init(MIX_INIT_MOD) != 0;
+    if (!Audio.sound_system_avail)
     {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, _("Error with sound: %s\n"), Mix_GetError());
     }

--- a/src/masmenu.cpp
+++ b/src/masmenu.cpp
@@ -135,11 +135,11 @@ void camp_spell_menu(int c)
 
     if (party[pidx[c]].IsMute())
     {
-        play_effect(SND_BAD, 128);
+        play_effect(Audio::eSound::SND_BAD, 128);
         return;
     }
     kmenu.update_equipstats();
-    play_effect(SND_MENU, 128);
+    play_effect(Audio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -166,7 +166,7 @@ void camp_spell_menu(int c)
             {
                 ptr[smove] = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.up())
         {
@@ -175,7 +175,7 @@ void camp_spell_menu(int c)
             {
                 ptr[smove] = 11;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.right())
         {
@@ -184,7 +184,7 @@ void camp_spell_menu(int c)
             {
                 pg[smove] = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.left())
         {
@@ -193,7 +193,7 @@ void camp_spell_menu(int c)
             {
                 pg[smove] = 4;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -288,7 +288,7 @@ static void camp_spell_targeting(size_t caster_fighter_index, size_t spell_numbe
             }
             if (need_spell(tg, spell_number) == 0)
             {
-                play_effect(SND_BAD, 128);
+                play_effect(Audio::eSound::SND_BAD, 128);
                 return;
             }
             fighter[caster_fighter_index].ctmem = tg;
@@ -319,11 +319,11 @@ static void camp_spell_targeting(size_t caster_fighter_index, size_t spell_numbe
                     Magic.adjust_hp(fighter_index, Combat.GetHealthAdjust(fighter_index));
                 }
             }
-            play_effect(SND_TWINKLE, 128);
+            play_effect(Audio::eSound::SND_TWINKLE, 128);
         }
         else
         {
-            play_effect(SND_TWINKLE, 128); /* this should be a failure sound */
+            play_effect(Audio::eSound::SND_TWINKLE, 128); /* this should be a failure sound */
         }
         kmenu.revert_equipstats();
     }

--- a/src/masmenu.cpp
+++ b/src/masmenu.cpp
@@ -135,11 +135,11 @@ void camp_spell_menu(int c)
 
     if (party[pidx[c]].IsMute())
     {
-        play_effect(Audio::eSound::SND_BAD, 128);
+        play_effect(KAudio::eSound::SND_BAD, 128);
         return;
     }
     kmenu.update_equipstats();
-    play_effect(Audio::eSound::SND_MENU, 128);
+    play_effect(KAudio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -166,7 +166,7 @@ void camp_spell_menu(int c)
             {
                 ptr[smove] = 0;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.up())
         {
@@ -175,7 +175,7 @@ void camp_spell_menu(int c)
             {
                 ptr[smove] = 11;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.right())
         {
@@ -184,7 +184,7 @@ void camp_spell_menu(int c)
             {
                 pg[smove] = 0;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.left())
         {
@@ -193,7 +193,7 @@ void camp_spell_menu(int c)
             {
                 pg[smove] = 4;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -288,7 +288,7 @@ static void camp_spell_targeting(size_t caster_fighter_index, size_t spell_numbe
             }
             if (need_spell(tg, spell_number) == 0)
             {
-                play_effect(Audio::eSound::SND_BAD, 128);
+                play_effect(KAudio::eSound::SND_BAD, 128);
                 return;
             }
             fighter[caster_fighter_index].ctmem = tg;
@@ -319,11 +319,11 @@ static void camp_spell_targeting(size_t caster_fighter_index, size_t spell_numbe
                     Magic.adjust_hp(fighter_index, Combat.GetHealthAdjust(fighter_index));
                 }
             }
-            play_effect(Audio::eSound::SND_TWINKLE, 128);
+            play_effect(KAudio::eSound::SND_TWINKLE, 128);
         }
         else
         {
-            play_effect(Audio::eSound::SND_TWINKLE, 128); /* this should be a failure sound */
+            play_effect(KAudio::eSound::SND_TWINKLE, 128); /* this should be a failure sound */
         }
         kmenu.revert_equipstats();
     }

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -245,7 +245,7 @@ void KMenu::menu(void)
 {
     int stop = 0, ptr = 0, z = -1;
 
-    play_effect(SND_MENU, 128);
+    play_effect(Audio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -262,7 +262,7 @@ void KMenu::menu(void)
             {
                 ptr = 5;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.down())
         {
@@ -271,7 +271,7 @@ void KMenu::menu(void)
             {
                 ptr = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         /* Allow player to rearrange the party at any time by pressing LEFT */
         if (PlayerInput.left())
@@ -345,7 +345,7 @@ void KMenu::display_quest_window(void)
     if (quest_list.size() == 0)
     {
         /* There was nothing.. */
-        play_effect(SND_BAD, 128);
+        play_effect(Audio::eSound::SND_BAD, 128);
         return;
     }
 
@@ -417,7 +417,7 @@ void KMenu::display_quest_window(void)
         // If player pressed any of the inputs, newSelectedQuest will have changed.
         if (newSelectedQuest != (int)currentQuestSelected)
         {
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
 
         // Positive modulus: Keep the selected quest
@@ -502,10 +502,10 @@ void KMenu::spec_items(void)
 
     if (num_items == 0)
     {
-        play_effect(SND_BAD, 128);
+        play_effect(Audio::eSound::SND_BAD, 128);
         return;
     }
-    play_effect(SND_MENU, 128);
+    play_effect(Audio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -533,12 +533,12 @@ void KMenu::spec_items(void)
         if (PlayerInput.down())
         {
             ptr = (ptr + 1) % num_items;
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.up())
         {
             ptr = (ptr - 1 + num_items) % num_items;
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.bctrl())
         {
@@ -559,7 +559,7 @@ void KMenu::status_screen(size_t fighter_index)
     uint32_t rect_fill_amount = 0, curr_fill, res_index, stats_y, equipment_index;
     size_t pidx_index, stats_index;
 
-    play_effect(SND_MENU, 128);
+    play_effect(Audio::eSound::SND_MENU, 128);
     pidx_index = pidx[fighter_index];
     update_equipstats();
     while (!stop)
@@ -677,17 +677,17 @@ void KMenu::status_screen(size_t fighter_index)
         {
             fighter_index--;
             pidx_index = pidx[fighter_index];
-            play_effect(SND_MENU, 128);
+            play_effect(Audio::eSound::SND_MENU, 128);
         }
         if (PlayerInput.right() && fighter_index < numchrs - 1)
         {
             fighter_index++;
             pidx_index = pidx[fighter_index];
-            play_effect(SND_MENU, 128);
+            play_effect(Audio::eSound::SND_MENU, 128);
         }
         if (PlayerInput.bctrl())
         {
-            play_effect(SND_MENU, 128);
+            play_effect(Audio::eSound::SND_MENU, 128);
             stop = 1;
         }
     }

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -245,7 +245,7 @@ void KMenu::menu(void)
 {
     int stop = 0, ptr = 0, z = -1;
 
-    play_effect(Audio::eSound::SND_MENU, 128);
+    play_effect(KAudio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -262,7 +262,7 @@ void KMenu::menu(void)
             {
                 ptr = 5;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.down())
         {
@@ -271,7 +271,7 @@ void KMenu::menu(void)
             {
                 ptr = 0;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         /* Allow player to rearrange the party at any time by pressing LEFT */
         if (PlayerInput.left())
@@ -345,7 +345,7 @@ void KMenu::display_quest_window(void)
     if (quest_list.size() == 0)
     {
         /* There was nothing.. */
-        play_effect(Audio::eSound::SND_BAD, 128);
+        play_effect(KAudio::eSound::SND_BAD, 128);
         return;
     }
 
@@ -417,7 +417,7 @@ void KMenu::display_quest_window(void)
         // If player pressed any of the inputs, newSelectedQuest will have changed.
         if (newSelectedQuest != (int)currentQuestSelected)
         {
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
 
         // Positive modulus: Keep the selected quest
@@ -502,10 +502,10 @@ void KMenu::spec_items(void)
 
     if (num_items == 0)
     {
-        play_effect(Audio::eSound::SND_BAD, 128);
+        play_effect(KAudio::eSound::SND_BAD, 128);
         return;
     }
-    play_effect(Audio::eSound::SND_MENU, 128);
+    play_effect(KAudio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -533,12 +533,12 @@ void KMenu::spec_items(void)
         if (PlayerInput.down())
         {
             ptr = (ptr + 1) % num_items;
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.up())
         {
             ptr = (ptr - 1 + num_items) % num_items;
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.bctrl())
         {
@@ -559,7 +559,7 @@ void KMenu::status_screen(size_t fighter_index)
     uint32_t rect_fill_amount = 0, curr_fill, res_index, stats_y, equipment_index;
     size_t pidx_index, stats_index;
 
-    play_effect(Audio::eSound::SND_MENU, 128);
+    play_effect(KAudio::eSound::SND_MENU, 128);
     pidx_index = pidx[fighter_index];
     update_equipstats();
     while (!stop)
@@ -677,17 +677,17 @@ void KMenu::status_screen(size_t fighter_index)
         {
             fighter_index--;
             pidx_index = pidx[fighter_index];
-            play_effect(Audio::eSound::SND_MENU, 128);
+            play_effect(KAudio::eSound::SND_MENU, 128);
         }
         if (PlayerInput.right() && fighter_index < numchrs - 1)
         {
             fighter_index++;
             pidx_index = pidx[fighter_index];
-            play_effect(Audio::eSound::SND_MENU, 128);
+            play_effect(KAudio::eSound::SND_MENU, 128);
         }
         if (PlayerInput.bctrl())
         {
-            play_effect(Audio::eSound::SND_MENU, 128);
+            play_effect(KAudio::eSound::SND_MENU, 128);
             stop = 1;
         }
     }

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -97,6 +97,10 @@ void KMusic::shutdown_music(void)
  */
 void KMusic::set_music_volume(int volume)
 {
+    if (Audio.sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
+    {
+        return;
+    }
     mvol = float(std::clamp(volume, 0, 250)) / 250.0f;
     Mix_VolumeMusic(int(dvol * mvol * float(MIX_MAX_VOLUME)));
 }
@@ -203,6 +207,10 @@ void KMusic::play_sample(void* chunk, int, int, int, int)
  */
 void KMusic::set_volume(int sound_volume)
 {
+    if (Audio.sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
+    {
+        return;
+    }
     dvol = float(std::clamp(sound_volume, 0, 250)) / 250.0f;
     Mix_Volume(-1, int(128.0f * dvol));
     Mix_VolumeMusic(int(dvol * mvol * float(MIX_MAX_VOLUME)));

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -41,6 +41,7 @@ struct Mix_MusicLoader
 {
     Mix_Music* operator()(const std::string&);
 };
+
 struct Mix_MusicDeleter
 {
     void operator()(Mix_Music* m)
@@ -48,10 +49,12 @@ struct Mix_MusicDeleter
         Mix_FreeMusic(m);
     }
 };
+
 struct Mix_ChunkLoader
 {
     Mix_Chunk* operator()(const std::string&);
 };
+
 struct Mix_ChunkDeleter
 {
     void operator()(Mix_Chunk*);
@@ -121,7 +124,7 @@ void KMusic::poll_music(void)
  */
 void KMusic::play_music(const std::string& music_name, long)
 {
-    if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
+    if (Audio.sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
     {
         return;
     }
@@ -145,7 +148,7 @@ void KMusic::play_music(const std::string& music_name, long)
  */
 void KMusic::stop_music(void)
 {
-    if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
+    if (Audio.sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
     {
         return;
     }
@@ -161,7 +164,7 @@ void KMusic::stop_music(void)
  */
 void KMusic::pause_music(void)
 {
-    if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
+    if (Audio.sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
     {
         return;
     }
@@ -175,7 +178,7 @@ void KMusic::pause_music(void)
  */
 void KMusic::resume_music(void)
 {
-    if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
+    if (Audio.sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
     {
         return;
     }
@@ -185,14 +188,16 @@ void KMusic::resume_music(void)
 void KMusic::play_effect(int, int)
 {
 }
+
 void KMusic::play_sample(void* chunk, int, int, int, int)
 {
-    if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
+    if (Audio.sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
     {
         return;
     }
     Mix_PlayChannel(-1, reinterpret_cast<Mix_Chunk*>(chunk), 0);
 }
+
 /* \brief Set overall sound volume.
  * \param   volume 0 (silent) to 250 (loudest)
  */
@@ -209,19 +214,23 @@ Mix_Music* Mix_MusicLoader::operator()(const std::string& music_name)
     auto mpath = kqres(eDirectories::MUSIC_DIR, music_name);
     return Mix_LoadMUS(mpath.c_str());
 }
+
 Mix_Chunk* Mix_ChunkLoader::operator()(const std::string& name)
 {
     auto path = kqres(eDirectories::DATA_DIR, name);
     return Mix_LoadWAV(path.c_str());
 }
+
 void Mix_ChunkDeleter::operator()(Mix_Chunk* chunk)
 {
     Mix_FreeChunk(chunk);
 }
+
 void* KMusic::get_sample(const string& s)
 {
     return sample_cache.get(s);
 }
+
 void KMusic::free_samples()
 {
     sample_cache.clear();

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -26,11 +26,12 @@
  * Interfaces to SDL2_Mixer
  */
 
+#include "music.h"
 #include "disk.h"
 #include "imgcache.h"
 #include "kq.h"
-#include "music.h"
 #include "platform.h"
+#include "setup.h"
 #include <SDL_mixer.h>
 #include <algorithm>
 #include <string>
@@ -120,7 +121,7 @@ void KMusic::poll_music(void)
  */
 void KMusic::play_music(const std::string& music_name, long)
 {
-    if (is_sound == 0)
+    if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
     {
         return;
     }
@@ -144,7 +145,7 @@ void KMusic::play_music(const std::string& music_name, long)
  */
 void KMusic::stop_music(void)
 {
-    if (is_sound == 0)
+    if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
     {
         return;
     }
@@ -160,7 +161,7 @@ void KMusic::stop_music(void)
  */
 void KMusic::pause_music(void)
 {
-    if (is_sound == 0)
+    if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
     {
         return;
     }
@@ -174,7 +175,7 @@ void KMusic::pause_music(void)
  */
 void KMusic::resume_music(void)
 {
-    if (is_sound == 0)
+    if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
     {
         return;
     }
@@ -186,7 +187,7 @@ void KMusic::play_effect(int, int)
 }
 void KMusic::play_sample(void* chunk, int, int, int, int)
 {
-    if (is_sound == 0)
+    if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
     {
         return;
     }

--- a/src/selector.cpp
+++ b/src/selector.cpp
@@ -348,12 +348,12 @@ static eMiniMenu mini_menu(int omask)
             if (cp == MM_OPTIONS_LEAVE)
             {
                 cp = MM_OPTIONS_JOIN;
-                play_effect(SND_CLICK, 128);
+                play_effect(KAudio::eSound::SND_CLICK, 128);
             }
             else if (cp == MM_OPTIONS_LEAD)
             {
                 cp = MM_OPTIONS_LEAVE;
-                play_effect(SND_CLICK, 128);
+                play_effect(KAudio::eSound::SND_CLICK, 128);
             }
             else
             {
@@ -365,12 +365,12 @@ static eMiniMenu mini_menu(int omask)
         {
             if (cp == MM_OPTIONS_JOIN)
             {
-                play_effect(SND_CLICK, 128);
+                play_effect(KAudio::eSound::SND_CLICK, 128);
                 cp = MM_OPTIONS_LEAVE;
             }
             else if (cp == MM_OPTIONS_LEAVE)
             {
-                play_effect(SND_CLICK, 128);
+                play_effect(KAudio::eSound::SND_CLICK, 128);
                 cp = MM_OPTIONS_LEAD;
             }
             else
@@ -390,7 +390,7 @@ static eMiniMenu mini_menu(int omask)
             }
             else
             {
-                play_effect(SND_BAD, 128);
+                play_effect(KAudio::eSound::SND_BAD, 128);
             }
         }
     }
@@ -549,7 +549,7 @@ ePIDX select_any_player(eTarget csa, unsigned int icn, const char* msg)
                 {
                     ptr--;
                 }
-                play_effect(SND_CLICK, 128);
+                play_effect(KAudio::eSound::SND_CLICK, 128);
             }
             if (PlayerInput.down())
             {
@@ -557,7 +557,7 @@ ePIDX select_any_player(eTarget csa, unsigned int icn, const char* msg)
                 {
                     ptr++;
                 }
-                play_effect(SND_CLICK, 128);
+                play_effect(KAudio::eSound::SND_CLICK, 128);
             }
 
             if (PlayerInput.balt())
@@ -941,7 +941,7 @@ int select_party(ePIDX* avail, size_t n_avail, size_t numchrs_max)
             if (hero == PIDX_UNDEFINED)
             {
                 /* Selected a space with no hero in it! */
-                play_effect(SND_BAD, 128);
+                play_effect(KAudio::eSound::SND_BAD, 128);
             }
             else
             {
@@ -1004,7 +1004,7 @@ int select_party(ePIDX* avail, size_t n_avail, size_t numchrs_max)
         }
         if (oldcur != cur)
         {
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
     }
     return 0;
@@ -1044,7 +1044,7 @@ int select_player(void)
             {
                 ptr = numchrs - 1;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.down())
         {
@@ -1056,7 +1056,7 @@ int select_player(void)
             {
                 ptr = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -50,6 +50,10 @@ using eSize::SCREEN_W;
 
 /*! \name Globals */
 
+KAudio::KAudio()
+{
+}
+
 /*! Debug level 0..3 */
 char debugging = 0;
 
@@ -176,11 +180,13 @@ void config_menu(void)
         citem(row[9], _("Cancel Key:"), kq_keyname(PlayerInput.bctrl.scancode), FNORMAL);
         citem(row[10], _("Menu Key:"), kq_keyname(PlayerInput.benter.scancode), FNORMAL);
         citem(row[11], _("System Menu Key:"), kq_keyname(PlayerInput.besc.scancode), FNORMAL);
-        citem(row[12], _("Sound System:"), is_sound ? _("ON") : _("OFF"), FNORMAL);
+
+        // Show "ON" when either initializing or ready; its color will differ below.
+        citem(row[12], _("Sound System:"), sound_initialized_and_ready != KAudio::eSoundSystem::NotInitialized ? _("ON") : _("OFF"), FNORMAL);
 
         fontColor = FNORMAL;
         /* TT: This needs to check for ==0 because 1 means sound init */
-        if (is_sound == 0)
+        if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
         {
             fontColor = FDARK;
         }
@@ -235,7 +241,7 @@ void config_menu(void)
         if (PlayerInput.up())
         {
             // "jump" over unusable options
-            if (ptr == 15 && is_sound == 0)
+            if (ptr == 15 && sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
             {
                 ptr -= 2;
             }
@@ -252,7 +258,7 @@ void config_menu(void)
         if (PlayerInput.down())
         {
             // "jump" over unusable options
-            if (ptr == 12 && is_sound == 0)
+            if (ptr == 12 && sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
             {
                 ptr += 2;
             }
@@ -334,38 +340,37 @@ void config_menu(void)
                 break;
             case 8:
                 getakey(PlayerInput.balt, "kalt");
-
                 break;
             case 9:
                 getakey(PlayerInput.bctrl, "kctrl");
                 break;
             case 10:
                 getakey(PlayerInput.benter, "kenter");
-
                 break;
             case 11:
                 getakey(PlayerInput.besc, "kesc");
                 break;
+
             case 12:
-                if (is_sound == 2)
+                if (sound_initialized_and_ready == KAudio::eSoundSystem::Ready)
                 {
                     sound_init();
                 }
                 else
                 {
-                    if (is_sound == 0)
+                    if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
                     {
-                        is_sound = 1;
+                        sound_initialized_and_ready = KAudio::eSoundSystem::Initialize;
                         Draw.print_font(double_buffer, 92 + 2, 204, _("...please wait..."), FNORMAL);
                         Draw.blit2screen();
                         sound_init();
                         Music.play_music(g_map.song_file, 0);
                     }
                 }
-                Config.set_config_int(NULL, "is_sound", is_sound != 0);
+                Config.set_config_int(NULL, "is_sound", sound_initialized_and_ready != KAudio::eSoundSystem::NotInitialized);
                 break;
             case 13:
-                if (is_sound == 2)
+                if (sound_initialized_and_ready == KAudio::eSoundSystem::Ready)
                 {
                     p = getavalue(_("Sound Volume"), 0, 25, gsvol / 10, true, sound_feedback);
                     if (p != -1)
@@ -384,7 +389,7 @@ void config_menu(void)
                 }
                 break;
             case 14:
-                if (is_sound == 2)
+                if (sound_initialized_and_ready == KAudio::eSoundSystem::Ready)
                 {
                     p = getavalue(_("Music Volume"), 0, 25, gmvol / 10, true, music_feedback);
                     if (p != -1)
@@ -603,7 +608,7 @@ static int load_samples(void)
         "blind.wav",    "inn.wav",      "confuse.wav", "dispel.wav", "doom.wav",     "drain.wav",   "gas.wav",
         "explode.wav"
     };
-    if (is_sound == 0)
+    if (sound_initialized_and_ready == KAudio::eSoundSystem::NotInitialized)
     {
         return 1;
     }
@@ -638,7 +643,7 @@ void parse_setup(void)
     should_stretch_view = Config.get_config_int(NULL, "stretch_view", 1) != 0;
     wait_retrace = Config.get_config_int(NULL, "wait_retrace", 1);
     show_frate = Config.get_config_int(NULL, "show_frate", 0) != 0;
-    is_sound = Config.get_config_int(NULL, "is_sound", 1);
+    sound_initialized_and_ready = Config.get_config_int(NULL, "is_sound", KAudio::eSoundSystem::Initialize);
     gmvol = Config.get_config_int(NULL, "gmvol", 250);
     gsvol = Config.get_config_int(NULL, "gsvol", 250);
     use_joy = Config.get_config_int(NULL, "use_joy", 0);
@@ -685,7 +690,7 @@ void play_effect(int efc, int panning)
 
     /* Patch provided by mattrope: */
     /* sfx array is empty if sound is not initialized */
-    if (is_sound)
+    if (sound_initialized_and_ready != KAudio::eSoundSystem::NotInitialized)
     {
         samp = sfx[efc];
     }
@@ -795,34 +800,34 @@ void show_help(void)
 }
 
 /*! \brief Initialize or shutdown sound system
- * \author JB
- * \date ????????
- * \remark On entry is_sound=1 to initialize,
- *         on exit is_sound=0 (failure) or 2 (success),
- *         is_sound=2 to shutdown,
- *         on exit is_sound=0
- * \remark 20020914 - 05:28 RB : Updated
- *  20020922 - ML : updated to use DUMB
- *  20020922 - ML : Changed to only reserving 8 voices. (32 seemed over-kill?)
+ *
+ * If sound_initialized_and_ready == eSoundSystem::Initialize on entry,
+ * then we want to initialize the sound system.
+ * - sound_initialized_and_ready will be set either to:
+ *   eSoundSystem::NotInitialized (failure) or
+ *   eSoundSystem::Ready (success)
+ *
+ * If sound_initialized_and_ready == eSoundSystem::Ready on entry,
+ * then we want to shut down the sound system.
+ * - sound_initialized_and_ready will be set to: eSoundSystem::NotInitialized
  */
 void sound_init(void)
 {
     if (!sound_avail)
     {
-        is_sound = 0;
+        sound_initialized_and_ready = KAudio::eSoundSystem::NotInitialized;
         return;
     }
-    switch (is_sound)
+    switch (sound_initialized_and_ready)
     {
-    case 1:
+    case KAudio::eSoundSystem::Initialize:
         Music.init_music();
-        is_sound = load_samples() ? 0 : 2; /* load the wav files */
+        sound_initialized_and_ready = load_samples() ? KAudio::eSoundSystem::NotInitialized : KAudio::eSoundSystem::Ready; /* load the wav files */
         break;
-    case 2:
-        /* TT: We forgot to add this line, causing phantom music to loop */
+    case KAudio::eSoundSystem::Ready:
         Music.stop_music();
         Music.free_samples();
-        is_sound = 0;
+        sound_initialized_and_ready = KAudio::eSoundSystem::NotInitialized;
         break;
     }
 }

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -57,7 +57,7 @@ char debugging = 0;
 char slow_computer = 0;
 
 /*  Internal variables  */
-static void* sfx[MAX_SAMPLES];
+static void* sfx[KAudio::eSound::MAX_SAMPLES];
 
 /*  Internal functions  */
 static int load_samples(void);
@@ -247,7 +247,7 @@ void config_menu(void)
             {
                 ptr = MENU_SIZE - 1;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.down())
         {
@@ -264,7 +264,7 @@ void config_menu(void)
             {
                 ptr = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -380,7 +380,7 @@ void config_menu(void)
                 else
                 /* Not as daft as it seems, SND_BAD also wobbles the screen */
                 {
-                    play_effect(SND_BAD, 128);
+                    play_effect(KAudio::eSound::SND_BAD, 128);
                 }
                 break;
             case 14:
@@ -398,7 +398,7 @@ void config_menu(void)
                 }
                 else
                 {
-                    play_effect(SND_BAD, 128);
+                    play_effect(KAudio::eSound::SND_BAD, 128);
                 }
                 break;
             case 15:
@@ -594,7 +594,7 @@ static Cache<Mix_Chunk, Mix_ChunkLoader, Mix_ChunkDeleter> sample_cache;
  */
 static int load_samples(void)
 {
-    static const char* sndfiles[MAX_SAMPLES] = {
+    static const char* sndfiles[KAudio::eSound::MAX_SAMPLES] = {
         "whoosh.wav",   "menumove.wav", "bad.wav",     "item.wav",   "equip.wav",    "deequip.wav", "buysell.wav",
         "twinkle.wav",  "scorch.wav",   "poison.wav",  "chop.wav",   "slash.wav",    "stab.wav",    "hit.wav",
         "ice.wav",      "wind.wav",     "quake.wav",   "black.wav",  "white.wav",    "bolt1.wav",   "flood.wav",
@@ -607,7 +607,7 @@ static int load_samples(void)
     {
         return 1;
     }
-    for (int index = 0; index < MAX_SAMPLES; index++)
+    for (int index = 0; index < KAudio::eSound::MAX_SAMPLES; index++)
     {
         sfx[index] = Music.get_sample(sndfiles[index]);
         if (!sfx[index])
@@ -698,7 +698,7 @@ void play_effect(int efc, int panning)
             Music.play_sample(samp, gsvol, panning, 1000, 0);
         }
         break;
-    case SND_BAD:
+    case KAudio::eSound::SND_BAD:
         fullblit(double_buffer, fx_buffer);
 
         if (samp)
@@ -713,7 +713,7 @@ void play_effect(int efc, int panning)
         }
         fullblit(fx_buffer, double_buffer);
         break;
-    case SND_EXPLODE:
+    case KAudio::eSound::SND_EXPLODE:
         fullblit(double_buffer, fx_buffer);
         clear_bitmap(double_buffer);
         get_palette(old);

--- a/src/sgame.cpp
+++ b/src/sgame.cpp
@@ -252,7 +252,7 @@ int KSaveGame::saveload(int am_saving)
     // Have no more than 5 savestate boxes onscreen, but fewer if NUMSG < 5
     max_onscreen = std::min(5, NUMSG);
 
-    play_effect(SND_MENU, 128);
+    play_effect(KAudio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -279,7 +279,7 @@ int KSaveGame::saveload(int am_saving)
                 top_pointer = NUMSG - max_onscreen;
             }
 
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.down())
         {
@@ -299,7 +299,7 @@ int KSaveGame::saveload(int am_saving)
                 top_pointer = 0;
             }
 
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.right())
         {
@@ -591,7 +591,7 @@ int KSaveGame::start_menu(bool skip_splash)
             {
                 ptr = 3;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
             redraw = 1;
         }
         if (PlayerInput.down())
@@ -604,7 +604,7 @@ int KSaveGame::start_menu(bool skip_splash)
             {
                 ptr = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
             redraw = 1;
         }
         if (PlayerInput.balt())
@@ -708,7 +708,7 @@ int KSaveGame::system_menu(void)
             {
                 ptr = 3;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         else if (PlayerInput.down())
         {
@@ -716,7 +716,7 @@ int KSaveGame::system_menu(void)
             {
                 ptr = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
 
         if (PlayerInput.balt())
@@ -735,7 +735,7 @@ int KSaveGame::system_menu(void)
                 }
                 else
                 {
-                    play_effect(SND_BAD, 128);
+                    play_effect(KAudio::eSound::SND_BAD, 128);
                 }
             }
 

--- a/src/shopmenu.cpp
+++ b/src/shopmenu.cpp
@@ -86,7 +86,7 @@ static void buy_item(int how_many, int item_no)
     cost = items[l].price * how_many;
     if (cost > Game.GetGold() || how_many == 0)
     {
-        play_effect(Audio::eSound::SND_BAD, 128);
+        play_effect(KAudio::eSound::SND_BAD, 128);
         return;
     }
     while (!stop)
@@ -113,10 +113,10 @@ static void buy_item(int how_many, int item_no)
     {
         Game.AddGold(-cost);
         shops[shop_no].items_current[item_no] -= how_many;
-        play_effect(Audio::eSound::SND_MONEY, 128);
+        play_effect(KAudio::eSound::SND_MONEY, 128);
         return;
     }
-    play_effect(Audio::eSound::SND_BAD, 128);
+    play_effect(KAudio::eSound::SND_BAD, 128);
     Draw.message(_("No room!"), -1, 0);
     return;
 }
@@ -208,7 +208,7 @@ static void buy_menu(void)
             {
                 yptr = num_shop_items - 1;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.down())
         {
@@ -220,17 +220,17 @@ static void buy_menu(void)
             {
                 yptr = 0;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.left() && xptr > 1)
         {
             xptr--;
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.right() && xptr < max_x)
         {
             xptr++;
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -527,7 +527,7 @@ void inn(const char* iname, uint32_t gold_per_character, int pay)
             {
                 my = 0;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.up())
         {
@@ -539,7 +539,7 @@ void inn(const char* iname, uint32_t gold_per_character, int pay)
             {
                 my = 0;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -574,7 +574,7 @@ static void sell_howmany(int item_no, size_t inv_page)
     prc = items[l].price;
     if (prc == 0)
     {
-        play_effect(Audio::eSound::SND_BAD, 128);
+        play_effect(KAudio::eSound::SND_BAD, 128);
         return;
     }
     // Maximum (total) number of items
@@ -672,7 +672,7 @@ static void sell_item(int itno, int qty_being_sold)
                     }
                 }
             }
-            play_effect(Audio::eSound::SND_MONEY, 128);
+            play_effect(KAudio::eSound::SND_MONEY, 128);
             remove_item(itno, qty_being_sold);
             stop = 1;
         }
@@ -766,7 +766,7 @@ static void sell_menu(void)
             {
                 yptr = 0;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.up())
         {
@@ -778,7 +778,7 @@ static void sell_menu(void)
             {
                 yptr = (NUM_ITEMS_PER_PAGE - 1);
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.left())
         {
@@ -790,7 +790,7 @@ static void sell_menu(void)
             {
                 inv_page = MAX_INV / NUM_ITEMS_PER_PAGE - 1;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.right())
         {
@@ -802,7 +802,7 @@ static void sell_menu(void)
             {
                 inv_page = 0;
             }
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -863,7 +863,7 @@ int shop(int shop_num)
         return 1;
     }
 
-    play_effect(Audio::eSound::SND_MENU, 128);
+    play_effect(KAudio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -883,12 +883,12 @@ int shop(int shop_num)
         if (PlayerInput.left() && ptr > 0)
         {
             ptr--;
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.right() && ptr < 2)
         {
             ptr++;
-            play_effect(Audio::eSound::SND_CLICK, 128);
+            play_effect(KAudio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {

--- a/src/shopmenu.cpp
+++ b/src/shopmenu.cpp
@@ -86,7 +86,7 @@ static void buy_item(int how_many, int item_no)
     cost = items[l].price * how_many;
     if (cost > Game.GetGold() || how_many == 0)
     {
-        play_effect(SND_BAD, 128);
+        play_effect(Audio::eSound::SND_BAD, 128);
         return;
     }
     while (!stop)
@@ -113,10 +113,10 @@ static void buy_item(int how_many, int item_no)
     {
         Game.AddGold(-cost);
         shops[shop_no].items_current[item_no] -= how_many;
-        play_effect(SND_MONEY, 128);
+        play_effect(Audio::eSound::SND_MONEY, 128);
         return;
     }
-    play_effect(SND_BAD, 128);
+    play_effect(Audio::eSound::SND_BAD, 128);
     Draw.message(_("No room!"), -1, 0);
     return;
 }
@@ -208,7 +208,7 @@ static void buy_menu(void)
             {
                 yptr = num_shop_items - 1;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.down())
         {
@@ -220,17 +220,17 @@ static void buy_menu(void)
             {
                 yptr = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.left() && xptr > 1)
         {
             xptr--;
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.right() && xptr < max_x)
         {
             xptr++;
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -527,7 +527,7 @@ void inn(const char* iname, uint32_t gold_per_character, int pay)
             {
                 my = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.up())
         {
@@ -539,7 +539,7 @@ void inn(const char* iname, uint32_t gold_per_character, int pay)
             {
                 my = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -574,7 +574,7 @@ static void sell_howmany(int item_no, size_t inv_page)
     prc = items[l].price;
     if (prc == 0)
     {
-        play_effect(SND_BAD, 128);
+        play_effect(Audio::eSound::SND_BAD, 128);
         return;
     }
     // Maximum (total) number of items
@@ -672,7 +672,7 @@ static void sell_item(int itno, int qty_being_sold)
                     }
                 }
             }
-            play_effect(SND_MONEY, 128);
+            play_effect(Audio::eSound::SND_MONEY, 128);
             remove_item(itno, qty_being_sold);
             stop = 1;
         }
@@ -766,7 +766,7 @@ static void sell_menu(void)
             {
                 yptr = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.up())
         {
@@ -778,7 +778,7 @@ static void sell_menu(void)
             {
                 yptr = (NUM_ITEMS_PER_PAGE - 1);
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.left())
         {
@@ -790,7 +790,7 @@ static void sell_menu(void)
             {
                 inv_page = MAX_INV / NUM_ITEMS_PER_PAGE - 1;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.right())
         {
@@ -802,7 +802,7 @@ static void sell_menu(void)
             {
                 inv_page = 0;
             }
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {
@@ -863,7 +863,7 @@ int shop(int shop_num)
         return 1;
     }
 
-    play_effect(SND_MENU, 128);
+    play_effect(Audio::eSound::SND_MENU, 128);
     while (!stop)
     {
         Game.ProcessEvents();
@@ -883,12 +883,12 @@ int shop(int shop_num)
         if (PlayerInput.left() && ptr > 0)
         {
             ptr--;
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.right() && ptr < 2)
         {
             ptr++;
-            play_effect(SND_CLICK, 128);
+            play_effect(Audio::eSound::SND_CLICK, 128);
         }
         if (PlayerInput.balt())
         {


### PR DESCRIPTION
Note: commit hash `0f27e90` renames `music_mix.cpp` onto `music.cpp`, which may conflict with some of the changes to music/sound that @pedro-w's working on. If we need to remove that, it's fine.

This creates a general-purpose KAudio class to shove the various music and sound initialization stuff into. There may be some overlap from this and the music work in #83.

We really just need to get all of these global functions/variables consolidated so it's easier to maintain and refactor.