### PR TITLE
Bugfixes for music player

### DIFF
--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -81,7 +81,7 @@ static void sound_feedback(int val)
 
 static void music_feedback(int val)
 {
-    Music.set_music_volume(val);
+    Music.set_music_volume(val * 10);
 }
 
 /*! \brief Draw a setting and its title
@@ -581,18 +581,6 @@ const char* kq_keyname(int scancode)
     return SDL_GetKeyName(kc);
 }
 
-struct Mix_ChunkLoader
-{
-    Mix_Chunk* operator()(const std::string&);
-};
-
-struct Mix_ChunkDeleter
-{
-    void operator()(Mix_Chunk*);
-};
-
-static Cache<Mix_Chunk, Mix_ChunkLoader, Mix_ChunkDeleter> sample_cache;
-
 /*! \brief Load sample files
  * \author JB
  * \date ????????
@@ -830,6 +818,8 @@ void sound_init(void)
     case KAudio::eSoundSystem::Initialize:
         Music.init_music();
         Audio.sound_initialized_and_ready = load_samples() ? KAudio::eSoundSystem::NotInitialized : KAudio::eSoundSystem::Ready; /* load the wav files */
+        Music.set_volume(gsvol);
+        Music.set_music_volume(gmvol);
         break;
     case KAudio::eSoundSystem::Ready:
         Music.stop_music();

--- a/src/sgame.cpp
+++ b/src/sgame.cpp
@@ -190,11 +190,11 @@ int KSaveGame::load_game(void)
 {
     sprintf(strbuf, "sg%d.xml", save_ptr);
     Disk.load_game_from_file(kqres(eDirectories::SAVE_DIR, strbuf).c_str());
-    hold_fade = 0;
-    Game.change_map(Game.GetCurmap(), g_ent[0].tilex, g_ent[0].tiley, g_ent[0].tilex, g_ent[0].tiley);
     /* Set music and sound volume */
     Music.set_volume(gsvol);
     Music.set_music_volume(gmvol);
+    hold_fade = 0;
+    Game.change_map(Game.GetCurmap(), g_ent[0].tilex, g_ent[0].tiley, g_ent[0].tilex, g_ent[0].tiley);
     return 1;
 }
 


### PR DESCRIPTION
1. ~~Don't attempt to change volume if music was never initialized~~ (this was dealt with in a previous PR)
2. Make sure to set the volume (as specified in the config file)
   when sound/music is initialized
3. When loading a game, set volume before the initial fade-in
4. Set the volume correctly when changing music volume on the
   config screen
5. Remove duplicate code