### PR TITLE
Manage entities with an Entity Manager

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -245,6 +245,11 @@ class KEntityManager
      * \param   target_entity Index of entity to move
      */
     void wander(t_entity target_entity);
+
+
+  public:
+    // Number of active entities (player + NPCs) on the current map.
+    uint32_t number_of_entities;
 };
 
 extern KEntityManager EntityManager;

--- a/include/entity.h
+++ b/include/entity.h
@@ -57,25 +57,193 @@ class KEntityManager
     ~KEntityManager() = default;
     KEntityManager();
 
+    /*! \brief Count active entities.
+     *
+     * Modifes the 'number_of_entities' variable.
+     *
+     * This actually calculates the last index of any active entity plus one,
+     * so if there are entities present, but not active, they may be counted.
+     */
     void count_entities();
+
+    /*! \brief Check entites at location
+     *
+     * Check for any entities in the specified co-ordinates.
+     * Runs combat routines if a character and an enemy meet,
+     * and de-activate the enemy if it was defeated.
+     *
+     * \param   ox x-coord to check
+     * \param   oy y-coord to check
+     * \param   who Id of entity doing the checking
+     * \returns index of entity found+1 or 0 if none found
+     */
     int entityat(int ox, int oy, t_entity who);
+
+    /*! \brief Set position
+     *
+     * Position an entity manually.
+     *
+     * \param   en Entity to position
+     * \param   ex x-coord
+     * \param   ey y-coord
+     */
     void place_ent(t_entity en, int ex, int ey);
+
+    /*! \brief Main entity routine
+     *
+     * The main routine that loops through the entity list and processes each
+     * one.
+     */
     void process_entities();
+
+    /*! \brief Initialize script
+     *
+     * This is used to set up an entity with a movement script so that
+     * it can be automatically controlled.
+     *
+     * \param   target_entity Entity to process
+     * \param   movestring The script
+     */
     void set_script(t_entity target_entity, const char* movestring);
 
   protected:
+    /*! \brief Chase player
+     *
+     * Chase after the main player #0, if he/she is near.
+     * Speed up until at maximum. If the player goes out
+     * of range, wander for a bit.
+     *
+     * \param   target_entity Index of entity
+     */
     void chase(t_entity target_entity);
+
+    /*! \brief Check proximity
+     *
+     * Check to see if the target is within "rad" squares.
+     * Test area is a square box rather than a circle
+     * target entity needs to be within the view area
+     * to be visible
+     *
+     * \param   eno Entity under consideration
+     * \param   tgt Entity to test
+     * \param   rad Radius to test within
+     * \returns true if near, false otherwise
+     */
     bool entity_near(t_entity eno, t_entity tgt, int rad);
+
+    /*! \brief Run script
+     *
+     * This executes script commands.  This is from Verge1.
+     *
+     * \param   target_entity Entity to process
+     */
     void entscript(t_entity target_entity);
+
+    /*! \brief Party following leader
+     *
+     * This makes any characters (after the first) follow the leader.
+     */
     void follow(int tile_x, int tile_y);
+
+    /*! \brief Read a command and parameter from a script
+     *
+     * This processes entity commands from the movement script.
+     * This is from Verge1.
+     *
+     * Script commands are:
+     * - U,R,D,L + param:  move up, right, down, left by param spaces
+     * - W+param: wait param frames
+     * - B: start script again
+     * - X+param: move to x-coord param
+     * - Y+param: move to y-coord param
+     * - F+param: face direction param (0=S, 1=N, 2=W, 3=E)
+     * - K: kill (remove) entity
+     *
+     * \param   target_entity Entity to process
+     */
     void getcommand(t_entity target_entity);
+
+    /*! \brief Generic movement
+     *
+     * Set up the entity vars to move in the given direction
+     *
+     * \param   target_entity Index of entity to move
+     * \param   dx tiles to move in x direction
+     * \param   dy tiles to move in y direction
+     */
     int move(t_entity target_entity, signed int dx, signed int dy);
+
+    /*! \brief Check for obstruction
+     *
+     * Check for any map-based obstructions in the specified co-ordinates.
+     *
+     * \param   origin_x Original x-coord position
+     * \param   origin_y Original y-coord position
+     * \param   move_x Amount to move -1..+1
+     * \param   move_y Amount to move -1..+1
+     * \param   check_entity Whether to return 1 if an entity is at the target
+     * \returns 1 if path is obstructed, 0 otherwise
+     */
     int obstruction(int origin_x, int origin_y, int move_x, int move_y, int check_entity);
+
+    /*! \brief Read an int from a script
+     *
+     * This parses the movement script for a value that relates
+     * to a command.  This is from Verge1.
+     *
+     * \param   target_entity Entity to process
+     */
     void parsems(t_entity target_entity);
+
+    /*! \brief Process movement for player
+     *
+     * This is the replacement for process_controls that used to be in kq.c
+     * I realized that all the work in process_controls was already being
+     * done in process_entity... I just had to make this exception for the
+     * player-controlled dude.
+     */
     void player_move();
+
+    /*! \brief Actions for one entity
+     * \date    20040310 PH added TARGET movemode, broke out chase into separate function
+     *
+     * Process an individual active entity.  If the entity in question is main character (#0)
+     * and the party is not automated, then allow for player input.
+     *
+     * \param   target_entity Index of entity
+     * \date    20040310 PH added TARGET movemode, broke out chase into separate function
+     */
     void process_entity(t_entity target_entity);
+
+    /*! \brief Adjust movement speed
+     *
+     * This has to adjust for each entity's speed.
+     * 'Normal' speed appears to be 4.
+     *
+     * \param   target_entity Index of entity
+     */
     void speed_adjust(t_entity target_entity);
+
+    /*! \brief Move entity towards target
+     * \author PH
+     * \date 20040310
+     *
+     * When entity is in target mode (MM_TARGET) move towards the goal.  This is
+     * fairly simple; it doesn't do clever obstacle avoidance.  It simply moves
+     * either horizontally or vertically, preferring the _closer_ one. In other
+     * words, it will try to get on a vertical or horizontal line with its target.
+     *
+     * \param   target_entity Index of entity
+     */
     void target(t_entity target_entity);
+
+    /*! \brief Move randomly
+     *
+     * Choose a random direction for the entity to walk in and set up the
+     * vars to do so.
+     *
+     * \param   target_entity Index of entity to move
+     */
     void wander(t_entity target_entity);
 };
 

--- a/include/entity.h
+++ b/include/entity.h
@@ -33,12 +33,6 @@
 
 typedef uint32_t t_entity;
 
-void process_entities(void);
-int entityat(int, int, t_entity);
-void set_script(t_entity, const char*);
-void place_ent(t_entity, int, int);
-void count_entities(void);
-
 enum eCommands
 {
     COMMAND_NONE = 0,
@@ -56,3 +50,33 @@ enum eCommands
 
     NUM_COMMANDS // always last
 };
+
+class KEntityManager
+{
+  public:
+    ~KEntityManager() = default;
+    KEntityManager();
+
+    void count_entities();
+    int entityat(int ox, int oy, t_entity who);
+    void place_ent(t_entity en, int ex, int ey);
+    void process_entities();
+    void set_script(t_entity target_entity, const char* movestring);
+
+  protected:
+    void chase(t_entity target_entity);
+    bool entity_near(t_entity eno, t_entity tgt, int rad);
+    void entscript(t_entity target_entity);
+    void follow(int tile_x, int tile_y);
+    void getcommand(t_entity target_entity);
+    int move(t_entity target_entity, signed int dx, signed int dy);
+    int obstruction(int origin_x, int origin_y, int move_x, int move_y, int check_entity);
+    void parsems(t_entity target_entity);
+    void player_move();
+    void process_entity(t_entity target_entity);
+    void speed_adjust(t_entity target_entity);
+    void target(t_entity target_entity);
+    void wander(t_entity target_entity);
+};
+
+extern KEntityManager EntityManager;

--- a/include/kq.h
+++ b/include/kq.h
@@ -462,8 +462,6 @@ extern s_anim tanim[MAX_TILESETS][MAX_ANIM];
 extern s_anim adata[MAX_ANIM];
 extern uint32_t numchrs;
 extern int gsvol, gmvol;
-/*! Number of entities (or enemies?) */
-extern uint32_t number_of_entities;
 extern ePIDX pidx[MAXCHRS];
 extern uint8_t autoparty, alldead, deadeffect, use_sstone;
 extern bool bDoesViewportFollowPlayer;

--- a/include/player.h
+++ b/include/player.h
@@ -88,7 +88,7 @@ class KPlayer
     string name;                 /*!< Entity name */
     int xp;                      /*!< Entity experience */
     int next;                    /*!< Experience needed for level-up */
-    int lvl;                     /*!< Entity's level */
+    int lvl;                     /*!< Entity's level (according to KMenu::check_xp(), max is 50) */
     int mrp;                     /*!< Magic use rate (0-100) */
     int hp;                      /*!< Hit points */
     int mhp;                     /*!< Maximum hit points */

--- a/include/structs.h
+++ b/include/structs.h
@@ -43,35 +43,35 @@ class Raster;
  * Contains info on an entity's appearance, position and behaviour */
 struct KQEntity
 {
-    uint8_t chrx;     //!< Entity's identity (what s/he looks like)
-    uint16_t x;       //!< x-coord on map
-    uint16_t y;       //!< y-coord on map
-    uint16_t tilex;   //!< x-coord tile that entity is standing on
-    uint16_t tiley;   //!< y-coord tile that entity is standing on
-    uint8_t eid;      //!< Entity type (fighter, enemy, normal)
-    uint8_t active;   //!< "Alive" or not
-    uint8_t facing;   //!< Direction
-    uint8_t moving;   //!< In the middle of a move
-    uint8_t movcnt;   //!< How far along the move entity is
-    uint8_t framectr; //!< Counter for determining animation frame
-    uint8_t movemode; //!< Stand, wander, script or chasing
-    uint8_t obsmode;  //!< Determine if affected by obstacles or not
-    uint8_t delay;    //!< Movement delay (between steps)
-    uint8_t delayctr; //!< Counter for movement delay
-    uint8_t speed;    //!< How hyperactive the entity is
-    uint8_t scount;
-    uint8_t cmd;  //!< Scripted commands (eCommands in entity.h)
-    uint8_t sidx; //!< Index within script parser
-    uint8_t extra;
-    uint8_t chasing;   //!< Entity is following another
-    signed int cmdnum; //!< Number of times we need to repeat 'cmd'
-    uint8_t atype;
-    uint8_t snapback;  //!< Snaps back to direction previously facing
-    uint8_t facehero;  //!< Look at player when talked to
-    uint8_t transl;    //!< Entity is see-through or not
-    char script[60];   //!< Movement/action script (pacing, etc.)
-    uint16_t target_x; //!< Scripted x-coord the ent is moving to
-    uint16_t target_y; //!< Scripted y-coord the ent is moving to
+    uint8_t chrx;       //!< Entity's identity (what s/he looks like)
+    uint16_t x;         //!< x-coord on map
+    uint16_t y;         //!< y-coord on map
+    uint16_t tilex;     //!< x-coord tile that entity is standing on
+    uint16_t tiley;     //!< y-coord tile that entity is standing on
+    uint8_t eid;        //!< Entity type (fighter, enemy, normal)
+    uint8_t active;     //!< "Alive" or not
+    uint8_t facing;     //!< Direction
+    uint8_t moving;     //!< In the middle of a move
+    uint8_t movcnt;     //!< How far along the move entity is, in pixels; 0 (not moving, or finished moving) up to 15 (TILE_W - 1)
+    uint8_t framectr;   //!< Counter for determining animation frame
+    uint8_t movemode;   //!< Stand, wander, script or chasing
+    uint8_t obsmode;    //!< Determine if affected by obstacles or not
+    uint8_t delay;      //!< Movement delay (between steps)
+    uint8_t delayctr;   //!< Counter for movement delay
+    uint8_t speed;      //!< How hyperactive the entity is
+    uint8_t scount;     //<< UNUSED
+    uint8_t cmd;        //!< Scripted commands (eCommands in entity.h)
+    uint8_t sidx;       //!< Index within script parser
+    uint8_t extra;      //!< Used with random numbers to detect when an entity should chase the player
+    uint8_t chasing;    //!< Entity is following another
+    signed int cmdnum;  //!< Number of times we need to repeat 'cmd'
+    uint8_t atype;      //!< UNUSED
+    uint8_t snapback;   //!< Snaps back to direction previously facing
+    uint8_t facehero;   //!< Look at player when talked to
+    uint8_t transl;     //!< Entity is see-through or not
+    char script[60];    //!< Movement/action script (pacing, etc.)
+    uint16_t target_x;  //!< Scripted x-coord the ent is moving to
+    uint16_t target_y;  //!< Scripted y-coord the ent is moving to
 };
 
 /*! \brief Animation specifier

--- a/src/disk.cpp
+++ b/src/disk.cpp
@@ -851,13 +851,13 @@ int KDisk::load_general_props_xml(XMLElement* node)
                     {
                         pidx[i] = static_cast<ePIDX>(*it++);
                         g_ent[i].eid = pidx[i];
-                        g_ent[i].active = 1;
+                        g_ent[i].active = true;
                         ++numchrs;
                     }
                     else
                     {
                         pidx[i] = PIDX_UNDEFINED;
-                        g_ent[i].active = 0;
+                        g_ent[i].active = false;
                     }
                 }
             }

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -353,7 +353,7 @@ void KDraw::draw_char()
     size_t fighter_frame, fighter_frame_add;
     size_t fighter_type_id;
 
-    for (follower_fighter_index = PSIZE + number_of_entities; follower_fighter_index > 0; follower_fighter_index--)
+    for (follower_fighter_index = PSIZE + EntityManager.number_of_entities; follower_fighter_index > 0; follower_fighter_index--)
     {
         fighter_index = follower_fighter_index - 1;
         fighter_type_id = g_ent[fighter_index].eid;

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -46,13 +46,14 @@
 
 using namespace eSize;
 
-constexpr size_t Coords(int tile_x, int tile_y)
+constexpr auto Coords(int tile_x, int tile_y)
 {
-    int index = std::clamp(g_map.xsize * tile_y + tile_x, 0U, g_map.xsize * g_map.ysize - 1);
+    auto index = std::clamp(g_map.xsize * tile_y + tile_x, 0U, g_map.xsize * g_map.ysize - 1);
     return index;
 }
 
 KEntityManager::KEntityManager()
+    : number_of_entities{0}
 {
 }
 
@@ -82,7 +83,7 @@ int KEntityManager::entityat(int ox, int oy, t_entity who)
                 {
                     if (Combat.combat(0) == 1)
                     {
-                        g_ent[who].active = 0;
+                        g_ent[who].active = false;
                     }
                     return 0;
                 }
@@ -94,7 +95,7 @@ int KEntityManager::entityat(int ox, int oy, t_entity who)
                 {
                     if (Combat.combat(0) == 1)
                     {
-                        g_ent[i].active = 0;
+                        g_ent[i].active = false;
                     }
                     return 0;
                 }
@@ -120,7 +121,7 @@ void KEntityManager::process_entities()
 {
     for (auto i = 0U; i < MAX_ENTITIES; i++)
     {
-        if (g_ent[i].active == 1)
+        if (g_ent[i].active)
         {
             speed_adjust(i);
         }
@@ -224,7 +225,7 @@ bool KEntityManager::entity_near(t_entity eno, t_entity tgt, int rad)
 void KEntityManager::entscript(t_entity target_entity)
 {
     KQEntity& ent = g_ent[target_entity];
-    if (ent.active == 0)
+    if (!ent.active)
     {
         return;
     }
@@ -397,7 +398,7 @@ void KEntityManager::getcommand(t_entity target_entity)
     case 'K':
         /* PH add: command K makes the entity disappear */
         ent.cmd = eCommands::COMMAND_KILL;
-        ent.active = 0;
+        ent.active = false;
         break;
     default:
 #ifdef DEBUGMODE
@@ -554,9 +555,9 @@ int KEntityManager::move(t_entity target_entity, signed int dx, signed int dy)
     // be triggered as though the entity walked over that tile.
     if (dx != 0 && dy != 0)
     {
-        const int source_tile = Coords(tile_x, tile_y);
-        const int dest_tile_x = Coords(tile_x + dx, tile_y);
-        const int dest_tile_y = Coords(tile_x, tile_y + dy);
+        const unsigned int source_tile = Coords(tile_x, tile_y);
+        const unsigned int dest_tile_x = Coords(tile_x + dx, tile_y);
+        const unsigned int dest_tile_y = Coords(tile_x, tile_y + dy);
 
         // Check whether the zone immediately to the left or right, OR the zone immediately
         // above or below, the entity is a different value (for example: the entity is standing
@@ -649,8 +650,8 @@ int KEntityManager::obstruction(int origin_x, int origin_y, int move_x, int move
     dest_y = origin_y + move_y;
 
     // Check the current and target tiles' obstacles
-    current_tile = Game.Map.obstacle_array[(origin_y * g_map.xsize) + origin_x];
-    target_tile = Game.Map.obstacle_array[(dest_y * g_map.xsize) + dest_x];
+    current_tile = Game.Map.obstacle_array[Coords(origin_x, origin_y)];
+    target_tile = Game.Map.obstacle_array[Coords(dest_x, dest_y)];
 
     // Return early if the destination tile is an obstruction
     if (target_tile == BLOCK_ALL)

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -20,11 +20,20 @@
 */
 
 /*! \file
- * \brief Entity functions
- *
- * \author JB
- * \date ??????
+ * \brief Entity management functions
  */
+
+#include "entity.h"
+
+#include "combat.h"
+#include "enums.h"
+#include "input.h"
+#include "intrface.h"
+#include "itemdefs.h"
+#include "kq.h"
+#include "menu.h"
+#include "random.h"
+#include "setup.h"
 
 #include <algorithm>
 #include <cassert>
@@ -35,33 +44,145 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "combat.h"
-#include "entity.h"
-#include "enums.h"
-#include "input.h"
-#include "intrface.h"
-#include "itemdefs.h"
-#include "kq.h"
-#include "menu.h"
-#include "random.h"
-#include "setup.h"
-
 using namespace eSize;
 
-/*  internal functions  */
-static void chase(t_entity);
-static bool entity_near(t_entity, t_entity, int);
-static void entscript(t_entity);
-static void follow(int, int);
-static void getcommand(t_entity);
-static int move(t_entity, int, int);
-static int obstruction(int, int, int, int, int);
-static void parsems(t_entity);
-static void player_move(void);
-static void process_entity(t_entity);
-static void speed_adjust(t_entity);
-static void target(t_entity);
-static void wander(t_entity);
+constexpr size_t Coords(int tile_x, int tile_y)
+{
+    int index = std::clamp(g_map.xsize * tile_y + tile_x, 0U, g_map.xsize * g_map.ysize - 1);
+    return index;
+}
+
+KEntityManager::KEntityManager()
+{
+}
+
+/*! \brief Count active entities
+ *
+ * Force calculation of the 'number_of_entities' variable.
+ * This actually calculates the last index of any active entity plus one,
+ * so if there are entities present, but not active, they may be counted.
+ */
+void KEntityManager::count_entities()
+{
+    number_of_entities = 0;
+    for (size_t entity_index = 0; entity_index < MAX_ENTITIES; entity_index++)
+    {
+        if (g_ent[entity_index].active == 1)
+        {
+            number_of_entities = entity_index + 1;
+        }
+    }
+}
+
+/*! \brief Check entites at location
+ *
+ * Check for any entities in the specified co-ordinates.
+ * Runs combat routines if a character and an enemy meet,
+ * and de-activate the enemy if it was defeated.
+ *
+ * \param   ox x-coord to check
+ * \param   oy y-coord to check
+ * \param   who Id of entity doing the checking
+ * \returns index of entity found+1 or 0 if none found
+ */
+int KEntityManager::entityat(int ox, int oy, t_entity who)
+{
+    t_entity i;
+
+    for (i = 0; i < MAX_ENTITIES; i++)
+    {
+        if (g_ent[i].active && ox == g_ent[i].tilex && oy == g_ent[i].tiley)
+        {
+            if (who >= PSIZE)
+            {
+                if (g_ent[who].eid == ID_ENEMY && i < PSIZE)
+                {
+                    if (Combat.combat(0) == 1)
+                    {
+                        g_ent[who].active = 0;
+                    }
+                    return 0;
+                }
+                return i + 1;
+            }
+            else
+            {
+                if (g_ent[i].eid == ID_ENEMY)
+                {
+                    if (Combat.combat(0) == 1)
+                    {
+                        g_ent[i].active = 0;
+                    }
+                    return 0;
+                }
+                if (i >= PSIZE)
+                {
+                    return i + 1;
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+/*! \brief Set position
+ *
+ * Position an entity manually.
+ *
+ * \param   en Entity to position
+ * \param   ex x-coord
+ * \param   ey y-coord
+ */
+void KEntityManager::place_ent(t_entity en, int ex, int ey)
+{
+    g_ent[en].tilex = ex;
+    g_ent[en].tiley = ey;
+    g_ent[en].x = g_ent[en].tilex * TILE_W;
+    g_ent[en].y = g_ent[en].tiley * TILE_H;
+}
+
+/*! \brief Main entity routine
+ *
+ * The main routine that loops through the entity list and processes each
+ * one.
+ */
+void KEntityManager::process_entities()
+{
+    for (auto i = 0U; i < MAX_ENTITIES; i++)
+    {
+        if (g_ent[i].active == 1)
+        {
+            speed_adjust(i);
+        }
+    }
+
+    /* Do timers */
+    auto t_evt = Game.get_timer_event();
+    if (t_evt)
+    {
+        do_timefunc(t_evt);
+    }
+}
+
+/*! \brief Initialize script
+ *
+ * This is used to set up an entity with a movement script so that
+ * it can be automatically controlled.
+ *
+ * \param   target_entity Entity to process
+ * \param   movestring The script
+ */
+void KEntityManager::set_script(t_entity target_entity, const char* movestring)
+{
+    KQEntity& ent = g_ent[target_entity];
+    ent.moving = 0;             // Stop entity from moving
+    ent.movcnt = 0;             // Reset the move counter to 0
+    ent.cmd = eCommands::COMMAND_NONE;
+    ent.sidx = 0;               // Reset script command index
+    ent.cmdnum = 0;             // There are no scripted commands
+    ent.movemode = MM_SCRIPT;   // Force the entity to follow the script
+    strncpy(ent.script, movestring, sizeof(ent.script));
+}
 
 /*! \brief Chase player
  *
@@ -71,11 +192,11 @@ static void wander(t_entity);
  *
  * \param   target_entity Index of entity
  */
-static void chase(t_entity target_entity)
+void KEntityManager::chase(t_entity target_entity)
 {
     int emoved = 0;
-    auto& ent = g_ent[target_entity];
-    auto& plr = g_ent[0];
+    KQEntity& ent = g_ent[target_entity];
+    KQEntity& plr = g_ent[0];
 
     if (ent.chasing == 0)
     {
@@ -131,26 +252,6 @@ static void chase(t_entity target_entity)
     }
 }
 
-/*! \brief Count active entities
- *
- * Force calculation of the 'number_of_entities' variable.
- * This actually calculates the last index of any active entity plus one,
- * so if there are entities present, but not active, they may be counted.
- */
-void count_entities(void)
-{
-    size_t entity_index;
-
-    number_of_entities = 0;
-    for (entity_index = 0; entity_index < MAX_ENTITIES; entity_index++)
-    {
-        if (g_ent[entity_index].active == 1)
-        {
-            number_of_entities = entity_index + 1;
-        }
-    }
-}
-
 /*! \brief Check proximity
  *
  * Check to see if the target is within "rad" squares.
@@ -163,70 +264,19 @@ void count_entities(void)
  * \param   rad Radius to test within
  * \returns true if near, false otherwise
  */
-static bool entity_near(t_entity eno, t_entity tgt, int rad)
+bool KEntityManager::entity_near(t_entity eno, t_entity tgt, int rad)
 {
-    auto& tnt = g_ent[tgt];
+    KQEntity& tnt = g_ent[tgt];
     int ax = tnt.tilex;
     int ay = tnt.tiley;
     if (ax >= view_x1 && ay >= view_y1 && ax <= view_x2 && ay <= view_y2)
     {
-        auto& ent = g_ent[eno];
+        KQEntity& ent = g_ent[eno];
         int ex = ent.tilex - ax;
         int ey = ent.tiley - ay;
         return ex >= -rad && ey >= -rad && ex <= rad && ey <= rad;
     }
     return false;
-}
-
-/*! \brief Check entites at location
- *
- * Check for any entities in the specified co-ordinates.
- * Runs combat routines if a character and an enemy meet,
- * and de-activate the enemy if it was defeated.
- *
- * \param   ox x-coord to check
- * \param   oy y-coord to check
- * \param   who Id of entity doing the checking
- * \returns index of entity found+1 or 0 if none found
- */
-int entityat(int ox, int oy, t_entity who)
-{
-    t_entity i;
-
-    for (i = 0; i < MAX_ENTITIES; i++)
-    {
-        if (g_ent[i].active && ox == g_ent[i].tilex && oy == g_ent[i].tiley)
-        {
-            if (who >= PSIZE)
-            {
-                if (g_ent[who].eid == ID_ENEMY && i < PSIZE)
-                {
-                    if (Combat.combat(0) == 1)
-                    {
-                        g_ent[who].active = 0;
-                    }
-                    return 0;
-                }
-                return i + 1;
-            }
-            else
-            {
-                if (g_ent[i].eid == ID_ENEMY)
-                {
-                    if (Combat.combat(0) == 1)
-                    {
-                        g_ent[i].active = 0;
-                    }
-                    return 0;
-                }
-                if (i >= PSIZE)
-                {
-                    return i + 1;
-                }
-            }
-        }
-    }
-    return 0;
 }
 
 /*! \brief Run script
@@ -235,9 +285,9 @@ int entityat(int ox, int oy, t_entity who)
  *
  * \param   target_entity Entity to process
  */
-static void entscript(t_entity target_entity)
+void KEntityManager::entscript(t_entity target_entity)
 {
-    auto& ent = g_ent[target_entity];
+    KQEntity& ent = g_ent[target_entity];
     if (ent.active == 0)
     {
         return;
@@ -248,40 +298,40 @@ static void entscript(t_entity target_entity)
     }
     switch (ent.cmd)
     {
-    case COMMAND_MOVE_UP:
+    case eCommands::COMMAND_MOVE_UP:
         if (move(target_entity, 0, -1))
         {
             ent.cmdnum--;
         }
         break;
-    case COMMAND_MOVE_DOWN:
+    case eCommands::COMMAND_MOVE_DOWN:
         if (move(target_entity, 0, 1))
         {
             ent.cmdnum--;
         }
         break;
-    case COMMAND_MOVE_LEFT:
+    case eCommands::COMMAND_MOVE_LEFT:
         if (move(target_entity, -1, 0))
         {
             ent.cmdnum--;
         }
         break;
-    case COMMAND_MOVE_RIGHT:
+    case eCommands::COMMAND_MOVE_RIGHT:
         if (move(target_entity, 1, 0))
         {
             ent.cmdnum--;
         }
         break;
-    case COMMAND_WAIT:
+    case eCommands::COMMAND_WAIT:
         ent.cmdnum--;
         break;
-    case COMMAND_FINISH_COMMANDS:
+    case eCommands::COMMAND_FINISH_COMMANDS:
         return;
-    case COMMAND_REPEAT:
+    case eCommands::COMMAND_REPEAT:
         ent.sidx = 0;
         ent.cmdnum = 0;
         break;
-    case COMMAND_MOVETO_X:
+    case eCommands::COMMAND_MOVETO_X:
         if (ent.tilex < ent.cmdnum)
         {
             move(target_entity, 1, 0);
@@ -295,7 +345,7 @@ static void entscript(t_entity target_entity)
             ent.cmdnum = 0;
         }
         break;
-    case COMMAND_MOVETO_Y:
+    case eCommands::COMMAND_MOVETO_Y:
         if (ent.tiley < ent.cmdnum)
         {
             move(target_entity, 0, 1);
@@ -309,7 +359,7 @@ static void entscript(t_entity target_entity)
             ent.cmdnum = 0;
         }
         break;
-    case COMMAND_FACE:
+    case eCommands::COMMAND_FACE:
         ent.facing = ent.cmdnum;
         ent.cmdnum = 0;
         break;
@@ -324,7 +374,7 @@ static void entscript(t_entity target_entity)
  *
  * This makes any characters (after the first) follow the leader.
  */
-static void follow(int tile_x, int tile_y)
+void KEntityManager::follow(int tile_x, int tile_y)
 {
     t_entity i;
 
@@ -361,10 +411,10 @@ static void follow(int tile_x, int tile_y)
  *
  * \param   target_entity Entity to process
  */
-static void getcommand(t_entity target_entity)
+void KEntityManager::getcommand(t_entity target_entity)
 {
     char s;
-    auto& ent = g_ent[target_entity];
+    KQEntity& ent = g_ent[target_entity];
 
     /* PH FIXME: prevented from running off end of string */
     if (ent.sidx < sizeof(ent.script))
@@ -379,58 +429,58 @@ static void getcommand(t_entity target_entity)
     {
     case 'u':
     case 'U':
-        ent.cmd = COMMAND_MOVE_UP;
+        ent.cmd = eCommands::COMMAND_MOVE_UP;
         parsems(target_entity);
         break;
     case 'd':
     case 'D':
-        ent.cmd = COMMAND_MOVE_DOWN;
+        ent.cmd = eCommands::COMMAND_MOVE_DOWN;
         parsems(target_entity);
         break;
     case 'l':
     case 'L':
-        ent.cmd = COMMAND_MOVE_LEFT;
+        ent.cmd = eCommands::COMMAND_MOVE_LEFT;
         parsems(target_entity);
         break;
     case 'r':
     case 'R':
-        ent.cmd = COMMAND_MOVE_RIGHT;
+        ent.cmd = eCommands::COMMAND_MOVE_RIGHT;
         parsems(target_entity);
         break;
     case 'w':
     case 'W':
-        ent.cmd = COMMAND_WAIT;
+        ent.cmd = eCommands::COMMAND_WAIT;
         parsems(target_entity);
         break;
     case '\0':
-        ent.cmd = COMMAND_FINISH_COMMANDS;
+        ent.cmd = eCommands::COMMAND_FINISH_COMMANDS;
         ent.movemode = MM_STAND;
         ent.cmdnum = 0;
         ent.sidx = 0;
         break;
     case 'b':
     case 'B':
-        ent.cmd = COMMAND_REPEAT;
+        ent.cmd = eCommands::COMMAND_REPEAT;
         break;
     case 'x':
     case 'X':
-        ent.cmd = COMMAND_MOVETO_X;
+        ent.cmd = eCommands::COMMAND_MOVETO_X;
         parsems(target_entity);
         break;
     case 'y':
     case 'Y':
-        ent.cmd = COMMAND_MOVETO_Y;
+        ent.cmd = eCommands::COMMAND_MOVETO_Y;
         parsems(target_entity);
         break;
     case 'f':
     case 'F':
-        ent.cmd = COMMAND_FACE;
+        ent.cmd = eCommands::COMMAND_FACE;
         parsems(target_entity);
         break;
     case 'k':
     case 'K':
         /* PH add: command K makes the entity disappear */
-        ent.cmd = COMMAND_KILL;
+        ent.cmd = eCommands::COMMAND_KILL;
         ent.active = 0;
         break;
     default:
@@ -453,19 +503,19 @@ static void getcommand(t_entity target_entity)
  * \param   dx tiles to move in x direction
  * \param   dy tiles to move in y direction
  */
-static int move(t_entity target_entity, int dx, int dy)
+int KEntityManager::move(t_entity target_entity, signed int dx, signed int dy)
 {
-    int tile_x, tile_y, source_tile, oldfacing;
-    auto& ent = g_ent[target_entity];
-
-    if (dx == 0 && dy == 0) // Speed optimization.
+    if (dx == 0 && dy == 0)
     {
+        // Not moving vertically OR horizontally? Nothing to do.
         return 0;
     }
 
-    tile_x = ent.x / TILE_W;
-    tile_y = ent.y / TILE_H;
-    oldfacing = ent.facing;
+    KQEntity& ent = g_ent[target_entity];
+
+    int tile_x = std::clamp(ent.x / TILE_W, 0, int(g_map.xsize * g_map.ysize - 1));
+    int tile_y = std::clamp(ent.y / TILE_H, 0, int(g_map.xsize * g_map.ysize - 1));
+    int oldfacing = ent.facing;
     if (dx < 0)
     {
         ent.facing = FACE_LEFT;
@@ -482,112 +532,193 @@ static int move(t_entity target_entity, int dx, int dy)
     {
         ent.facing = FACE_UP;
     }
-    if (tile_x + dx == -1 || tile_x + dx == (int)g_map.xsize || tile_y + dy == -1 || tile_y + dy == (int)g_map.ysize)
+    if (tile_x + dx < 0 || tile_x + dx >= (int)g_map.xsize ||
+        tile_y + dy < 0 || tile_y + dy >= (int)g_map.ysize)
     {
         return 0;
     }
+
+    // When ObstacleMode is false, this entity can walk through any obstructions, including other entities.
     if (ent.obsmode == 1)
     {
-        // Try to automatically walk/run around obstacle.
-        if (dx && obstruction(tile_x, tile_y, dx, 0, FALSE))
+        // If:  the entity is trying to move left or right, AND
+        //      there is a NON-entity obstruction on the tile in that cardinal direction
+        // Then: attempt to move around the obstacle diagonally
+        if (dx != 0 && obstruction(tile_x, tile_y, dx, 0, false))
         {
-            if (dy != -1 && oldfacing == ent.facing && !obstruction(tile_x, tile_y + 1, dx, 0, TRUE) &&
-                !obstruction(tile_x, tile_y, 0, 1, TRUE))
+            // If:  the entity was not trying to walk up (specifically, diagonally-up), AND
+            //      the entity is still facing the same direction as before (left or right), AND
+            //      there is NO obstruction/entity diagonally-down, AND
+            //      there is also NO obstruction/entity straight down
+            // Then: have the entity move diagonally-down.
+            if (dy >= 0 && oldfacing == ent.facing &&
+                !obstruction(tile_x, tile_y + 1, dx, 0, true) &&
+                !obstruction(tile_x, tile_y, 0, 1, true))
             {
+                // The entity may not have been trying moving down before, but make it try to now.
                 dy = 1;
             }
-            else if (dy != 1 && oldfacing == ent.facing && !obstruction(tile_x, tile_y - 1, dx, 0, TRUE) &&
-                     !obstruction(tile_x, tile_y, 0, -1, TRUE))
+            // If:  the entity was not trying to walk down (specifically, diagonally-down), AND
+            //      the entity is still facing the same direction as before (left or right), AND
+            //      there is NO obstruction/entity diagonally-up, AND
+            //      there is also NO obstruction straight up
+            // Then: have the entity move diagonally-up.
+            else if (dy <= 0 && oldfacing == ent.facing &&
+                !obstruction(tile_x, tile_y - 1, dx, 0, true) &&
+                !obstruction(tile_x, tile_y, 0, -1, true))
             {
+                // The entity may not have been trying moving up before, but make it try to now.
                 dy = -1;
             }
             else
             {
+                // Forbid movement to the left or right now.
                 dx = 0;
             }
         }
-        if (dy && obstruction(tile_x, tile_y, 0, dy, FALSE))
+
+        // If:  the entity is trying to move up or down, AND
+        //      there is a NON-entity obstruction on the tile in that cardinal direction
+        // Then: attempt to move around the obstacle diagonally
+        if (dy != 0 && obstruction(tile_x, tile_y, 0, dy, false))
         {
-            if (dx != -1 && oldfacing == ent.facing && !obstruction(tile_x + 1, tile_y, 0, dy, TRUE) &&
-                !obstruction(tile_x, tile_y, 1, 0, TRUE))
+            // If:  the entity was not trying to walk left (specifically, diagonally-left), AND
+            //      the entity is still facing the same direction as before (up or down), AND
+            //      there is NO obstruction/entity diagonally-right, AND
+            //      there is also NO obstruction/entity straight right
+            // Then: have the entity move diagonally-right.
+            if (dx >= 0 && oldfacing == ent.facing &&
+                !obstruction(tile_x + 1, tile_y, 0, dy, true) &&
+                !obstruction(tile_x, tile_y, 1, 0, true))
             {
+                // The entity may not have been trying moving right before, but make it try to now.
                 dx = 1;
             }
-            else if (dx != 1 && oldfacing == ent.facing && !obstruction(tile_x - 1, tile_y, 0, dy, TRUE) &&
-                     !obstruction(tile_x, tile_y, -1, 0, TRUE))
+            // If:  the entity was not trying to walk right (specifically, diagonally-right), AND
+            //      the entity is still facing the same direction as before (up or down), AND
+            //      there is NO obstruction/entity diagonally-left, AND
+            //      there is also NO obstruction/entity straight left
+            // Then: have the entity move diagonally-left.
+            else if (dx <= 0 && oldfacing == ent.facing &&
+                !obstruction(tile_x - 1, tile_y, 0, dy, true) &&
+                !obstruction(tile_x, tile_y, -1, 0, true))
             {
+                // The entity may not have been trying moving left before, but make it try to now.
                 dx = -1;
             }
             else
             {
+                // Forbid movement up or down now.
                 dy = 0;
             }
         }
-        if ((dx || dy) && obstruction(tile_x, tile_y, dx, dy, FALSE))
+
+        // If:  the above calculations didn't totally forbid the entity from moving, AND
+        //      the destination tile is obstructed (by anything other than another entity)
+        // Then: forbid the entity's movement now.
+        if ((dx != 0 || dy != 0) && obstruction(tile_x, tile_y, dx, dy, false))
         {
             dx = dy = 0;
         }
     }
 
-    if (!dx && !dy && oldfacing == ent.facing)
+    // If the entity's movement is forbidden AND it didn't change direction, nothing to do.
+    if (dx == 0 && dy == 0 && oldfacing == ent.facing)
     {
         return 0;
     }
 
-    if (ent.obsmode == 1 && entityat(tile_x + dx, tile_y + dy, target_entity))
+    // If the current entity can be affected by obstacles, AND
+    // there is another entity on the destination tile, nothing to do.
+    if (ent.obsmode == 1 && EntityManager.entityat(tile_x + dx, tile_y + dy, target_entity))
     {
         return 0;
     }
 
-    // Make sure that the player can't avoid special zones by moving diagonally.
-    if (dx && dy)
+    // Make sure that the entity can't avoid special zones by moving diagonally.
+    // Example:
+    //  ....    ....
+    //  .E..    .E5.
+    //  .5x.    ..x.
+    //  ....    ....
+    // If the entity 'E' is trying to move down-right to the target 'x', and zone '5'
+    // is either immediately below, or immediately right, of 'E', then the zone should
+    // be triggered as though the entity walked over that tile.
+    if (dx != 0 && dy != 0)
     {
-        source_tile = tile_y * g_map.xsize + tile_x;
-        int dest_tile_x = std::clamp(static_cast<unsigned int>(source_tile + dx), 0U, g_map.xsize * g_map.ysize - 1);
-        int dest_tile_y = std::clamp(static_cast<unsigned int>(source_tile + dy * g_map.xsize), 0U, g_map.xsize * g_map.ysize - 1);
+        const int source_tile = Coords(tile_x, tile_y);
+        const int dest_tile_x = Coords(tile_x + dx, tile_y);
+        const int dest_tile_y = Coords(tile_x, tile_y + dy);
+
+        // Check whether the zone immediately to the left or right, OR the zone immediately
+        // above or below, the entity is a different value (for example: the entity is standing
+        // on a tile with Zone '1' but the neighboring tile is Zone '2').
         if (Game.Map.zone_array[source_tile] != Game.Map.zone_array[dest_tile_x] ||
             Game.Map.zone_array[source_tile] != Game.Map.zone_array[dest_tile_y])
         {
+            // If the entity is facing an obstruction or another entity, then forbid movement
+            // in that direction, and instead, force the entity up or down (if the obstacle is
+            // left or right) OR left or right (if the obstacle is up or down).
             if (ent.facing == FACE_LEFT || ent.facing == FACE_RIGHT)
             {
-                if (!obstruction(tile_x, tile_y, dx, 0, TRUE))
+                // If:  facing left and the obstruction is to the left, OR
+                //      facing right and the obstruction is to the right,
+                // Then: forbid movement left or right (retain up/down movement).
+                if (obstruction(tile_x, tile_y, dx, 0, true))
                 {
-                    dy = 0;
+                    dx = 0;
                 }
                 else
                 {
-                    dx = 0;
+                    // The tile left or right of the entity is NOT obstructed by an obstacle or entity,
+                    // so forbid movement up or down instead.
+                    dy = 0;
                 }
             }
             else // They are facing up or down.
             {
-                if (!obstruction(tile_x, tile_y, 0, dy, TRUE))
+                // If:  facing up and the obstruction is above, OR
+                //      facing down and the obstruction is below,
+                // Then: forbid movement up or down (retain left/right movement).
+                if (obstruction(tile_x, tile_y, 0, dy, true))
                 {
-                    dx = 0;
+                    dy = 0;
                 }
                 else
                 {
-                    dy = 0;
+                    // The tile above or below the entity is NOT obstructed by an obstacle or entity,
+                    // so forbid movement left or right instead.
+                    dx = 0;
                 }
             }
         }
     }
 
     // Make sure player can't walk diagonally between active entities.
-    if (dx && dy)
+    if (dx != 0 && dy != 0)
     {
-        if (obstruction(tile_x, tile_y, dx, 0, TRUE) && obstruction(tile_x, tile_y, 0, dy, TRUE))
+        if (obstruction(tile_x, tile_y, dx, 0, true) &&
+            obstruction(tile_x, tile_y, 0, dy, true))
         {
             return 0;
         }
     }
 
+    // Increase the full tile the entity is considered at (even if they visually have not arrived there yet).
     ent.tilex = tile_x + dx;
     ent.tiley = tile_y + dy;
-    ent.y += dy;
+
+    // Move the entity in the target direction by 1 pixel.
     ent.x += dx;
+    ent.y += dy;
+
     ent.moving = 1;
-    ent.movcnt = 15;
+
+    // The entity moves 1 pixel per tick, and since its .x and/or .y were just advanced 1 pixel,
+    // set this to the size of a tile (either TILE_W or TILE_H if they are the same, else some
+    // other logic is going to have to be involved if the tile sizes are not equal).
+    ent.movcnt = TILE_W - 1;
+
     return 1;
 }
 
@@ -602,7 +733,7 @@ static int move(t_entity target_entity, int dx, int dy)
  * \param   check_entity Whether to return 1 if an entity is at the target
  * \returns 1 if path is obstructed, 0 otherwise
  */
-static int obstruction(int origin_x, int origin_y, int move_x, int move_y, int check_entity)
+int KEntityManager::obstruction(int origin_x, int origin_y, int move_x, int move_y, int check_entity)
 {
     int current_tile; // obstrution for current tile
     int target_tile;  // obstruction for destination tile
@@ -683,11 +814,11 @@ static int obstruction(int origin_x, int origin_y, int move_x, int move_y, int c
  *
  * \param   target_entity Entity to process
  */
-static void parsems(t_entity target_entity)
+void KEntityManager::parsems(t_entity target_entity)
 {
     uint32_t p = 0;
     char tok[10];
-    auto& ent = g_ent[target_entity];
+    KQEntity& ent = g_ent[target_entity];
     char s = ent.script[ent.sidx];
 
     // 48..57 are '0'..'9' ASCII
@@ -703,22 +834,6 @@ static void parsems(t_entity target_entity)
     ent.cmdnum = atoi(tok);
 }
 
-/*! \brief Set position
- *
- * Position an entity manually.
- *
- * \param   en Entity to position
- * \param   ex x-coord
- * \param   ey y-coord
- */
-void place_ent(t_entity en, int ex, int ey)
-{
-    g_ent[en].tilex = ex;
-    g_ent[en].tiley = ey;
-    g_ent[en].x = g_ent[en].tilex * TILE_W;
-    g_ent[en].y = g_ent[en].tiley * TILE_H;
-}
-
 /*! \brief Process movement for player
  *
  * This is the replacement for process_controls that used to be in kq.c
@@ -726,9 +841,9 @@ void place_ent(t_entity en, int ex, int ey)
  * done in process_entity... I just had to make this exception for the
  * player-controlled dude.
  */
-static void player_move(void)
+void KEntityManager::player_move()
 {
-    auto& plr = g_ent[0];
+    KQEntity& plr = g_ent[0];
     int oldx = plr.tilex;
     int oldy = plr.tiley;
 
@@ -778,29 +893,6 @@ static void player_move(void)
     }
 }
 
-/*! \brief Main entity routine
- *
- * The main routine that loops through the entity list and processes each
- * one.
- */
-void process_entities(void)
-{
-    for (auto i = 0U; i < MAX_ENTITIES; i++)
-    {
-        if (g_ent[i].active == 1)
-        {
-            speed_adjust(i);
-        }
-    }
-
-    /* Do timers */
-    auto t_evt = Game.get_timer_event();
-    if (t_evt)
-    {
-        do_timefunc(t_evt);
-    }
-}
-
 /*! \brief Actions for one entity
  * \date    20040310 PH added TARGET movemode, broke out chase into separate function
  *
@@ -810,9 +902,9 @@ void process_entities(void)
  * \param   target_entity Index of entity
  * \date    20040310 PH added TARGET movemode, broke out chase into separate function
  */
-static void process_entity(t_entity target_entity)
+void KEntityManager::process_entity(t_entity target_entity)
 {
-    auto& ent = g_ent[target_entity];
+    KQEntity& ent = g_ent[target_entity];
 
     ent.scount = 0;
 
@@ -839,7 +931,6 @@ static void process_entity(t_entity target_entity)
         {
             --ent.y;
         }
-        ent.movcnt--;
 
         if (ent.framectr < 20)
         {
@@ -849,12 +940,14 @@ static void process_entity(t_entity target_entity)
         {
             ent.framectr = 0;
         }
+
+        ent.movcnt--;
         if (ent.movcnt == 0)
         {
             ent.moving = 0;
             if (target_entity < PSIZE)
             {
-                auto& player = party[pidx[target_entity]];
+                KPlayer& player = party[pidx[target_entity]];
                 if (steps < STEPS_NEEDED)
                 {
                     steps++;
@@ -919,26 +1012,6 @@ static void process_entity(t_entity target_entity)
     }
 }
 
-/*! \brief Initialize script
- *
- * This is used to set up an entity with a movement script so that
- * it can be automatically controlled.
- *
- * \param   target_entity Entity to process
- * \param   movestring The script
- */
-void set_script(t_entity target_entity, const char* movestring)
-{
-    auto& ent = g_ent[target_entity];
-    ent.moving = 0;             // Stop entity from moving
-    ent.movcnt = 0;             // Reset the move counter to 0
-    ent.cmd = COMMAND_NONE;
-    ent.sidx = 0;               // Reset script command index
-    ent.cmdnum = 0;             // There are no scripted commands
-    ent.movemode = MM_SCRIPT;   // Force the entity to follow the script
-    strncpy(ent.script, movestring, sizeof(ent.script));
-}
-
 /*! \brief Adjust movement speed
  *
  * This has to adjust for each entity's speed.
@@ -946,9 +1019,9 @@ void set_script(t_entity target_entity, const char* movestring)
  *
  * \param   target_entity Index of entity
  */
-static void speed_adjust(t_entity target_entity)
+void KEntityManager::speed_adjust(t_entity target_entity)
 {
-    auto& ent = g_ent[target_entity];
+    KQEntity& ent = g_ent[target_entity];
     int speed = ent.speed;
     /* TT: This is to see if the player is "running" */
     if (PlayerInput.bctrl.isDown() && target_entity < PSIZE)
@@ -1009,11 +1082,11 @@ static void speed_adjust(t_entity target_entity)
  *
  * \param   target_entity Index of entity
  */
-static void target(t_entity target_entity)
+void KEntityManager::target(t_entity target_entity)
 {
     int dx, dy, ax, ay, emoved = 0;
 
-    auto& ent = g_ent[target_entity];
+    KQEntity& ent = g_ent[target_entity];
 
     ax = dx = ent.target_x - ent.tilex;
     ay = dy = ent.target_y - ent.tiley;
@@ -1087,9 +1160,9 @@ static void target(t_entity target_entity)
  *
  * \param   target_entity Index of entity to move
  */
-static void wander(t_entity target_entity)
+void KEntityManager::wander(t_entity target_entity)
 {
-    auto& ent = g_ent[target_entity];
+    KQEntity& ent = g_ent[target_entity];
 
     if (ent.delayctr < ent.delay)
     {
@@ -1113,3 +1186,5 @@ static void wander(t_entity target_entity)
         break;
     }
 }
+
+KEntityManager EntityManager;

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -56,12 +56,6 @@ KEntityManager::KEntityManager()
 {
 }
 
-/*! \brief Count active entities
- *
- * Force calculation of the 'number_of_entities' variable.
- * This actually calculates the last index of any active entity plus one,
- * so if there are entities present, but not active, they may be counted.
- */
 void KEntityManager::count_entities()
 {
     number_of_entities = 0;
@@ -74,17 +68,6 @@ void KEntityManager::count_entities()
     }
 }
 
-/*! \brief Check entites at location
- *
- * Check for any entities in the specified co-ordinates.
- * Runs combat routines if a character and an enemy meet,
- * and de-activate the enemy if it was defeated.
- *
- * \param   ox x-coord to check
- * \param   oy y-coord to check
- * \param   who Id of entity doing the checking
- * \returns index of entity found+1 or 0 if none found
- */
 int KEntityManager::entityat(int ox, int oy, t_entity who)
 {
     t_entity i;
@@ -125,14 +108,6 @@ int KEntityManager::entityat(int ox, int oy, t_entity who)
     return 0;
 }
 
-/*! \brief Set position
- *
- * Position an entity manually.
- *
- * \param   en Entity to position
- * \param   ex x-coord
- * \param   ey y-coord
- */
 void KEntityManager::place_ent(t_entity en, int ex, int ey)
 {
     g_ent[en].tilex = ex;
@@ -141,11 +116,6 @@ void KEntityManager::place_ent(t_entity en, int ex, int ey)
     g_ent[en].y = g_ent[en].tiley * TILE_H;
 }
 
-/*! \brief Main entity routine
- *
- * The main routine that loops through the entity list and processes each
- * one.
- */
 void KEntityManager::process_entities()
 {
     for (auto i = 0U; i < MAX_ENTITIES; i++)
@@ -164,14 +134,6 @@ void KEntityManager::process_entities()
     }
 }
 
-/*! \brief Initialize script
- *
- * This is used to set up an entity with a movement script so that
- * it can be automatically controlled.
- *
- * \param   target_entity Entity to process
- * \param   movestring The script
- */
 void KEntityManager::set_script(t_entity target_entity, const char* movestring)
 {
     KQEntity& ent = g_ent[target_entity];
@@ -184,14 +146,6 @@ void KEntityManager::set_script(t_entity target_entity, const char* movestring)
     strncpy(ent.script, movestring, sizeof(ent.script));
 }
 
-/*! \brief Chase player
- *
- * Chase after the main player #0, if he/she is near.
- * Speed up until at maximum. If the player goes out
- * of range, wander for a bit.
- *
- * \param   target_entity Index of entity
- */
 void KEntityManager::chase(t_entity target_entity)
 {
     int emoved = 0;
@@ -252,18 +206,6 @@ void KEntityManager::chase(t_entity target_entity)
     }
 }
 
-/*! \brief Check proximity
- *
- * Check to see if the target is within "rad" squares.
- * Test area is a square box rather than a circle
- * target entity needs to be within the view area
- * to be visible
- *
- * \param   eno Entity under consideration
- * \param   tgt Entity to test
- * \param   rad Radius to test within
- * \returns true if near, false otherwise
- */
 bool KEntityManager::entity_near(t_entity eno, t_entity tgt, int rad)
 {
     KQEntity& tnt = g_ent[tgt];
@@ -279,12 +221,6 @@ bool KEntityManager::entity_near(t_entity eno, t_entity tgt, int rad)
     return false;
 }
 
-/*! \brief Run script
- *
- * This executes script commands.  This is from Verge1.
- *
- * \param   target_entity Entity to process
- */
 void KEntityManager::entscript(t_entity target_entity)
 {
     KQEntity& ent = g_ent[target_entity];
@@ -370,10 +306,6 @@ void KEntityManager::entscript(t_entity target_entity)
     }
 }
 
-/*! \brief Party following leader
- *
- * This makes any characters (after the first) follow the leader.
- */
 void KEntityManager::follow(int tile_x, int tile_y)
 {
     t_entity i;
@@ -395,22 +327,6 @@ void KEntityManager::follow(int tile_x, int tile_y)
     }
 }
 
-/*! \brief Read a command and parameter from a script
- *
- * This processes entity commands from the movement script.
- * This is from Verge1.
- *
- * Script commands are:
- * - U,R,D,L + param:  move up, right, down, left by param spaces
- * - W+param: wait param frames
- * - B: start script again
- * - X+param: move to x-coord param
- * - Y+param: move to y-coord param
- * - F+param: face direction param (0=S, 1=N, 2=W, 3=E)
- * - K: kill (remove) entity
- *
- * \param   target_entity Entity to process
- */
 void KEntityManager::getcommand(t_entity target_entity)
 {
     char s;
@@ -495,14 +411,6 @@ void KEntityManager::getcommand(t_entity target_entity)
     }
 }
 
-/*! \brief Generic movement
- *
- * Set up the entity vars to move in the given direction
- *
- * \param   target_entity Index of entity to move
- * \param   dx tiles to move in x direction
- * \param   dy tiles to move in y direction
- */
 int KEntityManager::move(t_entity target_entity, signed int dx, signed int dy)
 {
     if (dx == 0 && dy == 0)
@@ -722,17 +630,6 @@ int KEntityManager::move(t_entity target_entity, signed int dx, signed int dy)
     return 1;
 }
 
-/*! \brief Check for obstruction
- *
- * Check for any map-based obstructions in the specified co-ordinates.
- *
- * \param   origin_x Original x-coord position
- * \param   origin_y Original y-coord position
- * \param   move_x Amount to move -1..+1
- * \param   move_y Amount to move -1..+1
- * \param   check_entity Whether to return 1 if an entity is at the target
- * \returns 1 if path is obstructed, 0 otherwise
- */
 int KEntityManager::obstruction(int origin_x, int origin_y, int move_x, int move_y, int check_entity)
 {
     int current_tile; // obstrution for current tile
@@ -807,13 +704,6 @@ int KEntityManager::obstruction(int origin_x, int origin_y, int move_x, int move
     return 0;
 }
 
-/*! \brief Read an int from a script
- *
- * This parses the movement script for a value that relates
- * to a command.  This is from Verge1.
- *
- * \param   target_entity Entity to process
- */
 void KEntityManager::parsems(t_entity target_entity)
 {
     uint32_t p = 0;
@@ -834,13 +724,6 @@ void KEntityManager::parsems(t_entity target_entity)
     ent.cmdnum = atoi(tok);
 }
 
-/*! \brief Process movement for player
- *
- * This is the replacement for process_controls that used to be in kq.c
- * I realized that all the work in process_controls was already being
- * done in process_entity... I just had to make this exception for the
- * player-controlled dude.
- */
 void KEntityManager::player_move()
 {
     KQEntity& plr = g_ent[0];
@@ -893,15 +776,6 @@ void KEntityManager::player_move()
     }
 }
 
-/*! \brief Actions for one entity
- * \date    20040310 PH added TARGET movemode, broke out chase into separate function
- *
- * Process an individual active entity.  If the entity in question is main character (#0)
- * and the party is not automated, then allow for player input.
- *
- * \param   target_entity Index of entity
- * \date    20040310 PH added TARGET movemode, broke out chase into separate function
- */
 void KEntityManager::process_entity(t_entity target_entity)
 {
     KQEntity& ent = g_ent[target_entity];
@@ -1012,13 +886,6 @@ void KEntityManager::process_entity(t_entity target_entity)
     }
 }
 
-/*! \brief Adjust movement speed
- *
- * This has to adjust for each entity's speed.
- * 'Normal' speed appears to be 4.
- *
- * \param   target_entity Index of entity
- */
 void KEntityManager::speed_adjust(t_entity target_entity)
 {
     KQEntity& ent = g_ent[target_entity];
@@ -1071,17 +938,6 @@ void KEntityManager::speed_adjust(t_entity target_entity)
     }
 }
 
-/*! \brief Move entity towards target
- * \author PH
- * \date 20040310
- *
- * When entity is in target mode (MM_TARGET) move towards the goal.  This is
- * fairly simple; it doesn't do clever obstacle avoidance.  It simply moves
- * either horizontally or vertically, preferring the _closer_ one. In other
- * words, it will try to get on a vertical or horizontal line with its target.
- *
- * \param   target_entity Index of entity
- */
 void KEntityManager::target(t_entity target_entity)
 {
     int dx, dy, ax, ay, emoved = 0;
@@ -1153,13 +1009,6 @@ void KEntityManager::target(t_entity target_entity)
     }
 }
 
-/*! \brief Move randomly
- *
- * Choose a random direction for the entity to walk in and set up the
- * vars to do so.
- *
- * \param   target_entity Index of entity to move
- */
 void KEntityManager::wander(t_entity target_entity)
 {
     KQEntity& ent = g_ent[target_entity];

--- a/src/intrface.cpp
+++ b/src/intrface.cpp
@@ -2533,7 +2533,7 @@ static int KQ_move_entity(lua_State* L)
         strcat(buffer, "K");
     }
 
-    set_script(entity_id, buffer);
+    EntityManager.set_script(entity_id, buffer);
     return 0;
 }
 
@@ -2629,7 +2629,7 @@ static int KQ_place_ent(lua_State* L)
         y = (int)lua_tonumber(L, 3);
     }
 
-    place_ent(a, x, y);
+    EntityManager.place_ent(a, x, y);
     return 0;
 }
 
@@ -3050,7 +3050,7 @@ static int KQ_set_ent_script(lua_State* L)
 {
     int a = real_entity_num(L, 1);
 
-    set_script(a, lua_tostring(L, 2));
+    EntityManager.set_script(a, lua_tostring(L, 2));
     return 0;
 }
 

--- a/src/intrface.cpp
+++ b/src/intrface.cpp
@@ -1025,7 +1025,7 @@ static void init_obj(lua_State* L)
     /* entity[] array */
     lua_newtable(L);
     /* entities */
-    for (i = 0; i < number_of_entities; ++i)
+    for (i = 0; i < EntityManager.number_of_entities; ++i)
     {
         lua_newtable(L);
         lua_pushvalue(L, -2);
@@ -1039,7 +1039,7 @@ static void init_obj(lua_State* L)
     for (i = 0; i < numchrs; ++i)
     {
         lua_getglobal(L, party[pidx[i]].name.c_str());
-        lua_rawseti(L, -2, i + number_of_entities);
+        lua_rawseti(L, -2, i + EntityManager.number_of_entities);
     }
     lua_setglobal(L, "entity");
 }
@@ -1051,7 +1051,7 @@ static int KQ_add_chr(lua_State* L)
     if (numchrs < PSIZE)
     {
         pidx[numchrs] = a;
-        g_ent[numchrs].active = 1;
+        g_ent[numchrs].active = true;
         g_ent[numchrs].eid = (int)a;
         g_ent[numchrs].chrx = 0;
         numchrs++;
@@ -1314,7 +1314,7 @@ static int KQ_char_getter(lua_State* L)
             break;
 
         case 15:
-            lua_pushnumber(L, ent->active);
+            lua_pushboolean(L, ent->active);
             break;
 
         case 16:
@@ -1436,7 +1436,7 @@ static int KQ_char_setter(lua_State* L)
             break;
 
         case 15:
-            ent->active = (int)lua_tonumber(L, 3);
+            ent->active = lua_toboolean(L, 3);
             break;
 
         default:
@@ -1862,7 +1862,7 @@ static int KQ_get_ent_active(lua_State* L)
 {
     int a = real_entity_num(L, 1);
 
-    lua_pushnumber(L, g_ent[a].active);
+    lua_pushboolean(L, g_ent[a].active);
     return 1;
 }
 
@@ -2026,7 +2026,7 @@ static int KQ_get_marker_tiley(lua_State* L)
 
 static int KQ_get_noe(lua_State* L)
 {
-    lua_pushnumber(L, number_of_entities);
+    lua_pushnumber(L, EntityManager.number_of_entities);
     return 1;
 }
 
@@ -2965,12 +2965,9 @@ static int KQ_set_desc(lua_State* L)
 static int KQ_set_ent_active(lua_State* L)
 {
     int a = real_entity_num(L, 1);
-    auto b = lua_tointeger(L, 2);
+    auto b = lua_toboolean(L, 2);
+    g_ent[a].active = b;
 
-    if (b == 0 || b == 1)
-    {
-        g_ent[a].active = b;
-    }
     return 0;
 }
 
@@ -3255,7 +3252,7 @@ static int KQ_set_noe(lua_State* L)
 
     if (a <= MAX_ENTITIES_PER_MAP + PSIZE)
     {
-        number_of_entities = a;
+        EntityManager.number_of_entities = a;
     }
     return 0;
 }
@@ -4165,7 +4162,7 @@ static int KQ_party_setter(lua_State* L)
                 memcpy(&g_ent[i], &g_ent[i + 1], sizeof(KQEntity));
             }
             --numchrs;
-            g_ent[numchrs].active = 0;
+            g_ent[numchrs].active = false;
             pidx[numchrs] = PIDX_UNDEFINED;
         }
         else if (lua_istable(L, 3))

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -374,7 +374,7 @@ void KGame::activate(void)
         do_zone(Game.Map.zone_array[q]);
     }
 
-    p = entityat(looking_at_x, looking_at_y, 0);
+    p = EntityManager.entityat(looking_at_x, looking_at_y, 0);
 
     if (p >= PSIZE)
     {
@@ -885,7 +885,7 @@ void KGame::kwait(int dtime)
         ProcessEvents();
         Music.poll_music();
         --dtime;
-        process_entities();
+        EntityManager.process_entities();
         do_check_animation();
         Draw.drawmap();
         Draw.blit2screen();
@@ -979,7 +979,7 @@ int main(int argc, char* argv[])
             while (!stop)
             {
                 Game.ProcessEvents();
-                process_entities();
+                EntityManager.process_entities();
                 Game.do_check_animation();
                 Draw.drawmap();
                 Draw.blit2screen();
@@ -1065,12 +1065,12 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
         if (msx == 0 && msy == 0)
         {
             // Place players at default map starting coords
-            place_ent(i, g_map.stx, g_map.sty);
+            EntityManager.place_ent(i, g_map.stx, g_map.sty);
         }
         else
         {
             // Place players at specific coordinates in the map
-            place_ent(i, msx, msy);
+            EntityManager.place_ent(i, msx, msy);
         }
 
         g_ent[i].speed = 4;
@@ -1080,6 +1080,8 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
 
     for (i = 0; i < MAX_ENTITIES; i++)
     {
+        // FIXME: This shouldn't be hard-coded into the game engine. Move it to a lua script.
+        // The enemy at index 38 within entities.png is a kind of non-moving "black blob" or cloak or something.
         if (g_ent[i].chrx == 38 && g_ent[i].active == 1)
         {
             g_ent[i].eid = ID_ENEMY;
@@ -1136,7 +1138,7 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
         g_ent[i].active = 1;
     }
 
-    count_entities();
+    EntityManager.count_entities();
 
     for (i = 0; i < MAX_ENTITIES; i++)
     {
@@ -1508,7 +1510,7 @@ void KGame::wait_for_entity(size_t first_entity_index, size_t last_entity_index)
     do
     {
         ProcessEvents();
-        process_entities();
+        EntityManager.process_entities();
         Music.poll_music();
         Game.do_check_animation();
         Draw.drawmap();
@@ -1548,7 +1550,7 @@ void KGame::warp(int wtx, int wty, int fspeed)
 
     for (entity_index = 0; entity_index < last_entity; entity_index++)
     {
-        place_ent(entity_index, wtx, wty);
+        EntityManager.place_ent(entity_index, wtx, wty);
         g_ent[entity_index].moving = 0;
         g_ent[entity_index].movcnt = 0;
         g_ent[entity_index].framectr = 0;

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -112,8 +112,6 @@ s_map g_map;
 /*! Current entities (players+NPCs) */
 KQEntity g_ent[MAX_ENTITIES];
 
-uint32_t number_of_entities = 0;
-
 /*! Identifies characters in the party */
 // Ideally, this would hold values 0..7 (ePIDX::SENSAR..ePIDX::NOSLOM) in whatever order they belonged to the current party.
 ePIDX pidx[MAXCHRS] = { ePIDX::PIDX_UNDEFINED };
@@ -1082,7 +1080,7 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
     {
         // FIXME: This shouldn't be hard-coded into the game engine. Move it to a lua script.
         // The enemy at index 38 within entities.png is a kind of non-moving "black blob" or cloak or something.
-        if (g_ent[i].chrx == 38 && g_ent[i].active == 1)
+        if (g_ent[i].chrx == 38 && g_ent[i].active)
         {
             g_ent[i].eid = ID_ENEMY;
             g_ent[i].speed = kqrandom->random_range_exclusive(1, 5);
@@ -1132,12 +1130,12 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
         tilex[i] = (uint16_t)i;
     }
 
-    number_of_entities = 0;
     for (i = 0; i < (size_t)numchrs; i++)
     {
-        g_ent[i].active = 1;
+        g_ent[i].active = true;
     }
 
+    EntityManager.number_of_entities = 0;
     EntityManager.count_entities();
 
     for (i = 0; i < MAX_ENTITIES; i++)
@@ -1520,7 +1518,7 @@ void KGame::wait_for_entity(size_t first_entity_index, size_t last_entity_index)
         for (entity_index = first_entity_index; entity_index <= last_entity_index; ++entity_index)
         {
             move_mode = g_ent[entity_index].movemode;
-            if (g_ent[entity_index].active == 1 && (move_mode == MM_SCRIPT || move_mode == MM_TARGET))
+            if (g_ent[entity_index].active && (move_mode == MM_SCRIPT || move_mode == MM_TARGET))
             {
                 any_following_entities = true;
                 break; // for()

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -275,7 +275,7 @@ static int search_paths(uint32_t entity_id, int* map, uint32_t step, uint32_t so
 
     int index = source_y * limit_x + source_x;
     int value = map[index];
-    if ((value != -1) && (value == 0 || value > (int)step) && (step == 1 || !entityat(source_x, source_y, entity_id)))
+    if ((value != -1) && (value == 0 || value > (int)step) && (step == 1 || !EntityManager.entityat(source_x, source_y, entity_id)))
     {
         map[index] = step;
 

--- a/src/selector.cpp
+++ b/src/selector.cpp
@@ -427,7 +427,7 @@ static void party_add(ePIDX id, int lead)
         }
         ++numchrs;
         t->eid = (uint8_t)id;
-        t->active = 1;
+        t->active = true;
         t->chrx = 0;
     }
 }
@@ -461,7 +461,7 @@ static void party_remove(ePIDX id)
             memmove(&pidx[pidx_index], &pidx[pidx_index + 1], sizeof(*pidx) * (numchrs - pidx_index));
             memmove(&g_ent[pidx_index], &g_ent[pidx_index + 1], sizeof(*g_ent) * (numchrs - pidx_index));
             pidx[numchrs] = PIDX_UNDEFINED;
-            g_ent[numchrs].active = 0;
+            g_ent[numchrs].active = false;
             return;
         }
     }

--- a/src/tiledmap.cpp
+++ b/src/tiledmap.cpp
@@ -402,7 +402,7 @@ vector<KQEntity> KTiledMap::load_tmx_entities(XMLElement const* el)
                 }
                 if (xprop->Attribute("name", "active"))
                 {
-                    entity.active = value->IntValue();
+                    entity.active = value->BoolValue();
                 }
                 if (xprop->Attribute("name", "facing"))
                 {


### PR DESCRIPTION
Adds a manager to handle entity data and logic processing.

- The first commit moves the functions from `entity.h` into a containing class, so everything that called them now prefixes the calls with `EntityManager.`. The functions in `entity.cpp` were sorted, but mainly kept intact.
- The second commit is mostly a noop; it moves the comments for each function into the class declaration (helps my IntelliSense/tooltips).
- The third commit moves `number_of_entities` into EntityManager, and starts treating `active` as a boolean instead of '=1' and '=0' all over the place. An attempt to make getters and setters for `number_of_entities` was started, but there were a few C-isms that caused issues, so I left them off for now.