### PR TITLE
#81 Fix crash due to entity follow script going out of bounds

### DIFF
--- a/include/enums.h
+++ b/include/enums.h
@@ -58,10 +58,10 @@ enum eShadow
 };
 
 #define MAX_TILES 1024
-#define MAXE 41
+#define MAXE 41                     //!< Max number of enemy types
 #define PSIZE 2U
 #define MAXFRAMES 12
-#define MAXEFRAMES 12
+#define MAXEFRAMES 12               //!< Max number of animation frames per enemy
 #define MAX_ENTITIES_PER_MAP 50
 #define MAX_ENTITIES (MAX_ENTITIES_PER_MAP + PSIZE)
 #define ID_ENEMY 254
@@ -230,7 +230,7 @@ enum eWeapon
     NUM_WEAPONS // always last
 };
 
-/*!\name Use modes
+/*! \name Use modes
  * Specify how an item can be used.
  */
 enum eItemUse

--- a/include/kq.h
+++ b/include/kq.h
@@ -94,6 +94,9 @@ class KMap
     ~KMap() = default;
     KMap();
 
+    /*! Current map */
+    s_map g_map;
+
     std::vector<eObstacle> obstacle_array;
     std::vector<eShadow> shadow_array;
     std::vector<int> zone_array;
@@ -109,8 +112,7 @@ class KGame
      * This loads a new map and performs all of the functions that accompany the loading of a new map.
      *
      * \param   map_name Base name of map (xxx -> maps/xxx.map)
-     * \param   player_x New x-coord for player. Pass 0 for msx and msy to use the 'default' position stored in the map
-     * file: s_map::stx and s_map::sty
+     * \param   player_x New x-coord for player. Pass 0 for msx and msy to use the 'default' position stored in the map file: s_map::stx and s_map::sty
      * \param   player_y New y-coord for player
      * \param   camera_x New x-coord for camera. Pass 0 for mvx and mvy to use the default: s_map::stx and s_map::sty)
      * \param   camera_y New y-coord for camera
@@ -453,7 +455,6 @@ extern uint8_t treasure[SIZE_TREASURE];
 extern uint8_t save_spells[SIZE_SAVE_SPELL];
 
 extern Raster* kfonts;
-extern s_map g_map;
 
 /* Total entities within the current map: players + NPCs */
 extern KQEntity g_ent[MAX_ENTITIES];

--- a/include/kq.h
+++ b/include/kq.h
@@ -103,6 +103,13 @@ class KMap
 
     size_t MapSize() const;
 
+    /*! Which map layers should be drawn. These are set when the map is loaded; see change_map() */
+    bool draw_background;
+    bool draw_middle;
+    bool draw_foreground;
+    bool draw_shadow;
+
+
     /*! Current map */
     s_map g_map;
 
@@ -493,7 +500,6 @@ extern char attack_string[39];
 extern volatile int animation_count;
 extern COLOR_MAP cmap;
 extern uint8_t can_run, do_staff_effect, display_desc;
-extern uint8_t draw_background, draw_middle, draw_foreground, draw_shadow;
 extern s_inventory g_inv[MAX_INV];
 extern s_special_item special_items[MAX_SPECIAL_ITEMS];
 extern short player_special_items[MAX_SPECIAL_ITEMS];

--- a/include/kq.h
+++ b/include/kq.h
@@ -94,6 +94,15 @@ class KMap
     ~KMap() = default;
     KMap();
 
+    /*! \brief Return a valid index within the current g_map: [0, g_map.xsize*g_map.ysize).
+     * \param tile_x Should be within the range [0, g_map.xsize).
+     * \param tile_y Should be within the range [0, g_map.ysize).
+     * \return Unsigned value within the range [0, g_map.xsize * g_map.ysize - 1].
+     */
+    size_t Clamp(signed int tile_x, signed int tile_y) const;
+
+    size_t MapSize() const;
+
     /*! Current map */
     s_map g_map;
 

--- a/include/kq.h
+++ b/include/kq.h
@@ -438,7 +438,11 @@ extern Raster* map_icons[MAX_TILES];
 
 extern Raster *back, *tc, *tc2, *bub[8], *b_shield, *b_shell, *b_repulse, *b_mp;
 extern Raster *cframes[NUM_FIGHTERS][MAXCFRAMES], *tcframes[NUM_FIGHTERS][MAXCFRAMES], *frames[MAXCHRS][MAXFRAMES];
-extern Raster *eframes[MAXE][MAXEFRAMES], *pgb[9], *sfonts[5], *bord[8];
+
+/*! Enemy animation frames */
+extern Raster* eframes[MAXE][MAXEFRAMES];
+
+extern Raster *pgb[9], *sfonts[5], *bord[8];
 extern Raster *menuptr, *mptr, *sptr, *stspics, *sicons, *bptr, *missbmp, *noway, *upptr, *dnptr;
 extern Raster* shadow[MAX_SHADOWS];
 

--- a/include/maps.h
+++ b/include/maps.h
@@ -87,7 +87,6 @@ struct s_map
     Raster* entity_tiles;
 };
 
-extern s_map g_map;
 
 /* Local Variables:     */
 /* mode: c              */

--- a/maps/cave6a.tmx
+++ b/maps/cave6a.tmx
@@ -53,11 +53,5 @@
   <object id="3" name="entrance" type="marker" x="1280" y="1312" width="16" height="16"/>
   <object id="4" name="exit" type="marker" x="240" y="384" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#0000ff" id="9" name="bounds">
-  <object id="5" name="bounds" type="bounds" x="-16" y="16" width="1456" height="1376">
-   <properties>
-    <property name="btile" value="0"/>
-   </properties>
-  </object>
- </objectgroup>
+ <objectgroup color="#0000ff" id="9" name="bounds"/>
 </map>

--- a/maps/cave6b.tmx
+++ b/maps/cave6b.tmx
@@ -59,11 +59,5 @@
   <object id="10" name="save_point" type="marker" x="608" y="1056" width="16" height="16"/>
   <object id="11" name="entrance" type="marker" x="1184" y="1104" width="16" height="16"/>
  </objectgroup>
- <objectgroup color="#0000ff" id="9" name="bounds">
-  <object id="12" name="bounds" type="bounds" x="0" y="-16" width="1408" height="1424">
-   <properties>
-    <property name="btile" value="0"/>
-   </properties>
-  </object>
- </objectgroup>
+ <objectgroup color="#0000ff" id="9" name="bounds"/>
 </map>

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -846,7 +846,7 @@ int KDraw::is_forestsquare(int fx, int fy)
         return 0;
     }
     auto mapseg = map_seg[(fy * Game.Map.g_map.xsize) + fx];
-    switch (mapseg)
+    switch (mapseg) //FIXME: The indexes of overworld forest tiles should come from either a map (.tmx) or a script (.lua).
     {
     case 63:
     case 65:
@@ -1573,6 +1573,7 @@ void KDraw::set_textpos(uint32_t entity_index)
 
 void KDraw::set_view(int vw, int x1, int y1, int x2, int y2)
 {
+    //FIXME: set_view(true) needs the x1,y1,x2,y2 parameters, but set_view(false) needs no parameters.
     view_on = vw;
     if (view_on)
     {

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -279,7 +279,7 @@ Raster* KDraw::copy_bitmap(Raster* target, Raster* source)
 
 void KDraw::draw_backlayer(void)
 {
-    auto box = calculate_box(g_map.map_mode == eMapMode::MAPMODE_1p2E3S || g_map.map_mode == eMapMode::MAPMODE_1E2p3S);
+    auto box = calculate_box(Game.Map.g_map.map_mode == eMapMode::MAPMODE_1p2E3S || Game.Map.g_map.map_mode == eMapMode::MAPMODE_1E2p3S);
     int tile_x1 = box.x_offset / TILE_W;
     int tile_x2 = (box.x_offset + SCREEN_W - 1) / TILE_W;
     int tile_y1 = box.y_offset / TILE_H;
@@ -301,7 +301,7 @@ void KDraw::draw_backlayer(void)
 
         for (int x = box.left; x <= box.right; x++)
         {
-            int here = y * g_map.xsize + x;
+            int here = y * Game.Map.g_map.xsize + x;
             int pix = map_seg[here];
             blit(map_icons[tilex[pix]], double_buffer, 0, 0, x * TILE_W - box.x_offset, y * TILE_H - box.y_offset, TILE_W, TILE_H);
         }
@@ -324,8 +324,8 @@ KDraw::PBound KDraw::calculate_box(bool is_parallax)
     int x = 0, y = 0;
     if (is_parallax)
     {
-        x = viewport_x_coord * g_map.pmult / g_map.pdiv;
-        y = viewport_y_coord * g_map.pmult / g_map.pdiv;
+        x = viewport_x_coord * Game.Map.g_map.pmult / Game.Map.g_map.pdiv;
+        y = viewport_y_coord * Game.Map.g_map.pmult / Game.Map.g_map.pdiv;
     }
     else
     {
@@ -461,9 +461,9 @@ void KDraw::draw_char()
                         // Final y-coord is same as starting y-coord
                         y = g_ent[fighter_index].tiley * TILE_H - viewport_y_coord;
                         // Where the tile is on the map that we will draw over
-                        there = (g_ent[fighter_index].tiley) * g_map.xsize + g_ent[fighter_index].tilex - horiz;
+                        there = (g_ent[fighter_index].tiley) * Game.Map.g_map.xsize + g_ent[fighter_index].tilex - horiz;
                         // Original position, before you started moving
-                        here = (g_ent[fighter_index].tiley - vert) * g_map.xsize + g_ent[fighter_index].tilex - horiz;
+                        here = (g_ent[fighter_index].tiley - vert) * Game.Map.g_map.xsize + g_ent[fighter_index].tilex - horiz;
                     }
                     else
                     {
@@ -474,9 +474,9 @@ void KDraw::draw_char()
                         // Final y-coord is above starting y-coord
                         y = (g_ent[fighter_index].tiley - vert) * TILE_H - viewport_y_coord;
                         // Where the tile is on the map that we will draw over
-                        there = (g_ent[fighter_index].tiley - vert) * g_map.xsize + g_ent[fighter_index].tilex;
+                        there = (g_ent[fighter_index].tiley - vert) * Game.Map.g_map.xsize + g_ent[fighter_index].tilex;
                         // Target position
-                        here = (g_ent[fighter_index].tiley) * g_map.xsize + g_ent[fighter_index].tilex;
+                        here = (g_ent[fighter_index].tiley) * Game.Map.g_map.xsize + g_ent[fighter_index].tilex;
                     }
 
                     /* Because of possible redraw problems, only draw if there is
@@ -519,13 +519,13 @@ void KDraw::draw_char()
 
 void KDraw::draw_forelayer(void)
 {
-    KDraw::PBound box = calculate_box(g_map.map_mode == eMapMode::MAPMODE_1E2p3S || g_map.map_mode == eMapMode::MAPMODE_1P2E3S);
+    KDraw::PBound box = calculate_box(Game.Map.g_map.map_mode == eMapMode::MAPMODE_1E2p3S || Game.Map.g_map.map_mode == eMapMode::MAPMODE_1P2E3S);
     for (int y = box.top; y <= box.bottom; y++)
     {
         for (int x = box.left; x <= box.right; x++)
         {
             // Used in several places in this loop, so shortened the name
-            int here = y * g_map.xsize + x;
+            int here = y * Game.Map.g_map.xsize + x;
             int pix = f_seg[here];
             draw_sprite(double_buffer, map_icons[tilex[pix]], + x * TILE_W - box.x_offset, y * TILE_H - box.y_offset);
 
@@ -617,12 +617,12 @@ void KDraw::draw_kq_box(Raster* where, int x1, int y1, int x2, int y2, int bg, e
 
 void KDraw::draw_midlayer(void)
 {
-    auto box = calculate_box(g_map.map_mode == eMapMode::MAPMODE_1E2p3S || g_map.map_mode == eMapMode::MAPMODE_1P2E3S);
+    auto box = calculate_box(Game.Map.g_map.map_mode == eMapMode::MAPMODE_1E2p3S || Game.Map.g_map.map_mode == eMapMode::MAPMODE_1P2E3S);
     for (int y = box.top; y <= box.bottom; y++)
     {
         for (int x = box.left; x <= box.right; x++)
         {
-            int here = y * g_map.xsize + x;
+            int here = y * Game.Map.g_map.xsize + x;
             int pix = b_seg[here];
             draw_sprite(double_buffer, map_icons[tilex[pix]], x * TILE_W - box.x_offset, y * TILE_H - box.y_offset);
         }
@@ -640,7 +640,7 @@ void KDraw::draw_shadows(void)
     {
         for (int x = box.left; x <= box.right; x++)
         {
-            int here = y * g_map.xsize + x;
+            int here = y * Game.Map.g_map.xsize + x;
             eShadow pix = Game.Map.shadow_array[here];
             if (pix > eShadow::SHADOW_NONE)
             {
@@ -727,7 +727,7 @@ void KDraw::draw_porttextbox(eBubbleStyle bstyle, int chr)
 
 void KDraw::drawmap(void)
 {
-    if (g_map.xsize <= 0)
+    if (Game.Map.g_map.xsize <= 0)
     {
         clear_to_color(double_buffer, 1);
         return;
@@ -737,7 +737,7 @@ void KDraw::drawmap(void)
 
     /* Is the player standing inside a bounding area? */
     const KBound* found;
-    if ((found = g_map.bounds.IsBound(ent_x, ent_y, ent_x, ent_y)) != nullptr)
+    if ((found = Game.Map.g_map.bounds.IsBound(ent_x, ent_y, ent_x, ent_y)) != nullptr)
     {
         view_on = 1;
         view_y1 = found->top;
@@ -750,9 +750,9 @@ void KDraw::drawmap(void)
     {
         view_on = 0;
         view_y1 = 0;
-        view_y2 = g_map.ysize - 1;
+        view_y2 = Game.Map.g_map.ysize - 1;
         view_x1 = 0;
-        view_x2 = g_map.xsize - 1;
+        view_x2 = Game.Map.g_map.xsize - 1;
     }
 
     clear_bitmap(double_buffer);
@@ -760,7 +760,7 @@ void KDraw::drawmap(void)
     {
         draw_backlayer();
     }
-    if (g_map.map_mode == eMapMode::MAPMODE_1E23S || g_map.map_mode == eMapMode::MAPMODE_1E2p3S || g_map.map_mode == eMapMode::MAPMODE_12EP3S)
+    if (Game.Map.g_map.map_mode == eMapMode::MAPMODE_1E23S || Game.Map.g_map.map_mode == eMapMode::MAPMODE_1E2p3S || Game.Map.g_map.map_mode == eMapMode::MAPMODE_12EP3S)
     {
         draw_char();
     }
@@ -768,7 +768,7 @@ void KDraw::drawmap(void)
     {
         draw_midlayer();
     }
-    if (g_map.map_mode == eMapMode::MAPMODE_12E3S || g_map.map_mode == eMapMode::MAPMODE_1p2E3S || g_map.map_mode == eMapMode::MAPMODE_1P2E3S)
+    if (Game.Map.g_map.map_mode == eMapMode::MAPMODE_12E3S || Game.Map.g_map.map_mode == eMapMode::MAPMODE_1p2E3S || Game.Map.g_map.map_mode == eMapMode::MAPMODE_1P2E3S)
     {
         draw_char();
     }
@@ -786,8 +786,8 @@ void KDraw::drawmap(void)
     }
     if (display_desc == 1)
     {
-        menubox(double_buffer, 152 - (g_map.map_desc.length() * 4), 8, g_map.map_desc.length(), 1, BLUE);
-        print_font(double_buffer, 160 - (g_map.map_desc.length() * 4), 16, g_map.map_desc.c_str(), FNORMAL);
+        menubox(double_buffer, 152 - (Game.Map.g_map.map_desc.length() * 4), 8, Game.Map.g_map.map_desc.length(), 1, BLUE);
+        print_font(double_buffer, 160 - (Game.Map.g_map.map_desc.length() * 4), 16, Game.Map.g_map.map_desc.c_str(), FNORMAL);
     }
 }
 
@@ -845,7 +845,7 @@ int KDraw::is_forestsquare(int fx, int fy)
     {
         return 0;
     }
-    auto mapseg = map_seg[(fy * g_map.xsize) + fx];
+    auto mapseg = map_seg[(fy * Game.Map.g_map.xsize) + fx];
     switch (mapseg)
     {
     case 63:
@@ -1585,8 +1585,8 @@ void KDraw::set_view(int vw, int x1, int y1, int x2, int y2)
     {
         view_x1 = 0;
         view_y1 = 0;
-        view_x2 = g_map.xsize - 1;
-        view_y2 = g_map.ysize - 1;
+        view_x2 = Game.Map.g_map.xsize - 1;
+        view_y2 = Game.Map.g_map.ysize - 1;
     }
 }
 

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -301,8 +301,7 @@ void KDraw::draw_backlayer(void)
 
         for (int x = box.left; x <= box.right; x++)
         {
-            int here = y * Game.Map.g_map.xsize + x;
-            int pix = map_seg[here];
+            size_t pix = map_seg[Game.Map.Clamp(x, y)];
             blit(map_icons[tilex[pix]], double_buffer, 0, 0, x * TILE_W - box.x_offset, y * TILE_H - box.y_offset, TILE_W, TILE_H);
         }
         for (int x = box.right + 1; x <= tile_x2; x++)
@@ -322,7 +321,7 @@ void KDraw::draw_backlayer(void)
 KDraw::PBound KDraw::calculate_box(bool is_parallax)
 {
     int x = 0, y = 0;
-    if (is_parallax)
+    if (is_parallax && Game.Map.g_map.pdiv != 0)
     {
         x = viewport_x_coord * Game.Map.g_map.pmult / Game.Map.g_map.pdiv;
         y = viewport_y_coord * Game.Map.g_map.pmult / Game.Map.g_map.pdiv;
@@ -341,32 +340,23 @@ KDraw::PBound KDraw::calculate_box(bool is_parallax)
 
 void KDraw::draw_char()
 {
-    signed int dx, dy;
-    int f;
-    int x, y;
-    signed int horiz, vert;
-    unsigned int here, there;
-    Raster** sprite_base;
-    Raster* spr = NULL;
-    size_t follower_fighter_index;
-    size_t fighter_index;
-    size_t fighter_frame, fighter_frame_add;
-    size_t fighter_type_id;
-
-    for (follower_fighter_index = PSIZE + EntityManager.number_of_entities; follower_fighter_index > 0; follower_fighter_index--)
+    for (size_t follower_fighter_index = PSIZE + EntityManager.number_of_entities; follower_fighter_index > 0; follower_fighter_index--)
     {
-        fighter_index = follower_fighter_index - 1;
-        fighter_type_id = g_ent[fighter_index].eid;
-        dx = g_ent[fighter_index].x - viewport_x_coord;
-        dy = g_ent[fighter_index].y - viewport_y_coord;
-        if (!g_ent[fighter_index].moving)
+        size_t fighter_index = follower_fighter_index - 1;
+        KQEntity& follower_entity = g_ent[fighter_index];
+
+        signed int dx = follower_entity.x - viewport_x_coord;
+        signed int dy = follower_entity.y - viewport_y_coord;
+
+        size_t fighter_frame = follower_entity.facing * ENT_FRAMES_PER_DIR;
+        if (follower_entity.moving)
         {
-            fighter_frame = g_ent[fighter_index].facing * ENT_FRAMES_PER_DIR + 2;
+            size_t fighter_frame_add = follower_entity.framectr > 10 ? 1 : 0;
+            fighter_frame = follower_entity.facing * ENT_FRAMES_PER_DIR + fighter_frame_add;
         }
         else
         {
-            fighter_frame_add = g_ent[fighter_index].framectr > 10 ? 1 : 0;
-            fighter_frame = g_ent[fighter_index].facing * ENT_FRAMES_PER_DIR + fighter_frame_add;
+            fighter_frame = follower_entity.facing * ENT_FRAMES_PER_DIR + 2;
         }
 
         if (fighter_index < PSIZE && fighter_index < numchrs)
@@ -374,11 +364,13 @@ void KDraw::draw_char()
             /* It's a hero */
             /* Masquerade: if chrx!=0 then this hero is disguised as someone else...
              */
-            sprite_base = g_ent[fighter_index].chrx ? eframes[g_ent[fighter_index].chrx] : frames[fighter_type_id];
+            const size_t fighter_type_id = follower_entity.eid;
+            Raster** sprite_base = follower_entity.chrx ? eframes[follower_entity.chrx] : frames[fighter_type_id];
+            Raster* spr = nullptr;
 
             if (party[fighter_type_id].IsDead())
             {
-                fighter_frame = g_ent[fighter_index].facing * ENT_FRAMES_PER_DIR + 2;
+                fighter_frame = follower_entity.facing * ENT_FRAMES_PER_DIR + 2;
             }
             if (party[fighter_type_id].IsPoisoned())
             {
@@ -390,15 +382,15 @@ void KDraw::draw_char()
             {
                 spr = sprite_base[fighter_frame];
             }
-            if (is_forestsquare(g_ent[fighter_index].tilex, g_ent[fighter_index].tiley))
+
+            if (is_forestsquare(follower_entity.tilex, follower_entity.tiley))
             {
-                f = !g_ent[fighter_index].moving;
-                if (g_ent[fighter_index].moving &&
-                    is_forestsquare(g_ent[fighter_index].x / TILE_W, g_ent[fighter_index].y / TILE_H))
+                bool f = follower_entity.moving;
+                if (f && is_forestsquare(follower_entity.x / TILE_W, follower_entity.y / TILE_H))
                 {
-                    f = 1;
+                    f = false;
                 }
-                if (f)
+                if (!f)
                 {
                     clear_to_color(tc, 0);
                     blit(spr, tc, 0, 0, 0, 0, 16, 6); // 16,6 = avatar's width and top 6 pixels of height (head only)
@@ -421,89 +413,96 @@ void KDraw::draw_char()
              * We also need to ensure that the target coords has SOMETHING in the
              * obstacle_array[] portion, else there will be graphical glitches.
              */
-            if (fighter_index == 0 && g_ent[0].moving)
+            if (fighter_index > 0 || !g_ent[0].moving)
             {
-                horiz = 0;
-                vert = 0;
-                /* Determine the direction moving */
+                continue;
+            }
 
-                if (g_ent[fighter_index].tilex * TILE_W > g_ent[fighter_index].x)
+            /* Determine the direction moving */
+            signed int horiz = 0;
+            signed int vert = 0;
+            if (follower_entity.tilex * TILE_W > follower_entity.x)
+            {
+                horiz = 1; // Right
+            }
+            else if (follower_entity.tilex * TILE_W < follower_entity.x)
+            {
+                horiz = -1; // Left
+            }
+
+            if (follower_entity.tiley * TILE_H > follower_entity.y)
+            {
+                vert = 1; // Down
+            }
+            else if (follower_entity.tiley * TILE_H < follower_entity.y)
+            {
+                vert = -1; // Up
+            }
+
+            /* Moving diagonally means both horiz and vert are non-zero */
+            if (horiz != 0 && vert != 0)
+            {
+                signed int x = 0;
+                signed int y = 0;
+                size_t here = 0;
+                size_t there = 0;
+
+                /* When moving down, we will draw over the spot directly below
+                    * our starting position. Since tile[xy] shows our final coord,
+                    * we will instead draw to the left or right of the final pos.
+                    */
+                if (vert > 0)
                 {
-                    horiz = 1; // Right
+                    /* Moving diag down */
+
+                    // Final x-coord is one left/right of starting x-coord
+                    x = (follower_entity.tilex - horiz) * TILE_W - viewport_x_coord;
+                    // Final y-coord is same as starting y-coord
+                    y = follower_entity.tiley * TILE_H - viewport_y_coord;
+                    // Where the tile is on the map that we will draw over
+                    there = Game.Map.Clamp(follower_entity.tilex - horiz, follower_entity.tiley);
+                    // Original position, before you started moving
+                    here = Game.Map.Clamp(follower_entity.tilex - horiz, follower_entity.tiley - vert);
                 }
-                else if (g_ent[fighter_index].tilex * TILE_W < g_ent[fighter_index].x)
+                else
                 {
-                    horiz = -1; // Left
+                    /* Moving diag up */
+
+                    // Final x-coord is same as starting x-coord
+                    x = follower_entity.tilex * TILE_W - viewport_x_coord;
+                    // Final y-coord is above starting y-coord
+                    y = (follower_entity.tiley - vert) * TILE_H - viewport_y_coord;
+                    // Where the tile is on the map that we will draw over
+                    there = Game.Map.Clamp(follower_entity.tilex, follower_entity.tiley - vert);
+                    // Target position
+                    here = Game.Map.Clamp(follower_entity.tilex, follower_entity.tiley);
                 }
 
-                if (g_ent[fighter_index].tiley * TILE_H > g_ent[fighter_index].y)
+                /* Because of possible redraw problems, only draw if there is
+                 * something drawn over the player (f_seg[] != 0)
+                 */
+                if (tilex[f_seg[here]] != 0)
                 {
-                    vert = 1; // Down
-                }
-                else if (g_ent[fighter_index].tiley * TILE_H < g_ent[fighter_index].y)
-                {
-                    vert = -1; // Up
-                }
-
-                /* Moving diagonally means both horiz and vert are non-zero */
-                if (horiz && vert)
-                {
-                    /* When moving down, we will draw over the spot directly below
-                     * our starting position. Since tile[xy] shows our final coord,
-                     * we will instead draw to the left or right of the final pos.
-                     */
-                    if (vert > 0)
-                    {
-                        /* Moving diag down */
-
-                        // Final x-coord is one left/right of starting x-coord
-                        x = (g_ent[fighter_index].tilex - horiz) * TILE_W - viewport_x_coord;
-                        // Final y-coord is same as starting y-coord
-                        y = g_ent[fighter_index].tiley * TILE_H - viewport_y_coord;
-                        // Where the tile is on the map that we will draw over
-                        there = (g_ent[fighter_index].tiley) * Game.Map.g_map.xsize + g_ent[fighter_index].tilex - horiz;
-                        // Original position, before you started moving
-                        here = (g_ent[fighter_index].tiley - vert) * Game.Map.g_map.xsize + g_ent[fighter_index].tilex - horiz;
-                    }
-                    else
-                    {
-                        /* Moving diag up */
-
-                        // Final x-coord is same as starting x-coord
-                        x = g_ent[fighter_index].tilex * TILE_W - viewport_x_coord;
-                        // Final y-coord is above starting y-coord
-                        y = (g_ent[fighter_index].tiley - vert) * TILE_H - viewport_y_coord;
-                        // Where the tile is on the map that we will draw over
-                        there = (g_ent[fighter_index].tiley - vert) * Game.Map.g_map.xsize + g_ent[fighter_index].tilex;
-                        // Target position
-                        here = (g_ent[fighter_index].tiley) * Game.Map.g_map.xsize + g_ent[fighter_index].tilex;
-                    }
-
-                    /* Because of possible redraw problems, only draw if there is
-                     * something drawn over the player (f_seg[] != 0)
-                     */
-                    if (tilex[f_seg[here]] != 0)
-                    {
-                        draw_sprite(double_buffer, map_icons[tilex[map_seg[there]]], x, y);
-                        draw_sprite(double_buffer, map_icons[tilex[b_seg[there]]], x, y);
-                    }
+                    draw_sprite(double_buffer, map_icons[tilex[map_seg[there]]], x, y);
+                    draw_sprite(double_buffer, map_icons[tilex[b_seg[there]]], x, y);
                 }
             }
         }
         else
         {
             /* It's an NPC */
-            if (g_ent[fighter_index].active && g_ent[fighter_index].tilex >= view_x1 &&
-                g_ent[fighter_index].tilex <= view_x2 && g_ent[fighter_index].tiley >= view_y1 &&
-                g_ent[fighter_index].tiley <= view_y2)
+            if (follower_entity.active &&
+                follower_entity.tilex >= view_x1 && follower_entity.tilex <= view_x2 &&
+                follower_entity.tiley >= view_y1 && follower_entity.tiley <= view_y2)
             {
-                if (dx >= TILE_W * -1 && dx <= TILE_W * (ONSCREEN_TILES_W + 1) && dy >= TILE_H * -1 &&
-                    dy <= TILE_H * (ONSCREEN_TILES_H + 1))
+                if (dx >= TILE_W * -1 && dx <= TILE_W * (ONSCREEN_TILES_W + 1) &&
+                    dy >= TILE_H * -1 && dy <= TILE_H * (ONSCREEN_TILES_H + 1))
                 {
-                    spr = (g_ent[fighter_index].eid >= ID_ENEMY) ? eframes[g_ent[fighter_index].chrx][fighter_frame]
-                                                                 : frames[g_ent[fighter_index].eid][fighter_frame];
+                    const uint8_t eid = follower_entity.eid;
+                    const uint8_t chrx = follower_entity.chrx;
+                    Raster* spr = (eid >= ID_ENEMY) ? eframes[chrx][fighter_frame] : frames[eid][fighter_frame];
 
-                    if (g_ent[fighter_index].transl == 0)
+                    if (follower_entity.transl == 0)
                     {
                         draw_sprite(double_buffer, spr, dx, dy);
                     }
@@ -525,8 +524,8 @@ void KDraw::draw_forelayer(void)
         for (int x = box.left; x <= box.right; x++)
         {
             // Used in several places in this loop, so shortened the name
-            int here = y * Game.Map.g_map.xsize + x;
-            int pix = f_seg[here];
+            const size_t here = Game.Map.Clamp(x, y);
+            const size_t pix = f_seg[here];
             draw_sprite(double_buffer, map_icons[tilex[pix]], + x * TILE_W - box.x_offset, y * TILE_H - box.y_offset);
 
 #ifdef DEBUGMODE
@@ -622,8 +621,8 @@ void KDraw::draw_midlayer(void)
     {
         for (int x = box.left; x <= box.right; x++)
         {
-            int here = y * Game.Map.g_map.xsize + x;
-            int pix = b_seg[here];
+            size_t here = Game.Map.Clamp(x, y);
+            size_t pix = b_seg[here];
             draw_sprite(double_buffer, map_icons[tilex[pix]], x * TILE_W - box.x_offset, y * TILE_H - box.y_offset);
         }
     }
@@ -631,7 +630,7 @@ void KDraw::draw_midlayer(void)
 
 void KDraw::draw_shadows(void)
 {
-    if (draw_shadow == 0)
+    if (!draw_shadow)
     {
         return;
     }
@@ -640,11 +639,11 @@ void KDraw::draw_shadows(void)
     {
         for (int x = box.left; x <= box.right; x++)
         {
-            int here = y * Game.Map.g_map.xsize + x;
+            const size_t here = Game.Map.Clamp(x, y);
             eShadow pix = Game.Map.shadow_array[here];
-            if (pix > eShadow::SHADOW_NONE)
+            if (pix > eShadow::SHADOW_NONE && pix < eShadow::NUM_SHADOWS)
             {
-                draw_trans_sprite(double_buffer, shadow[pix], x * 16 - box.x_offset, y * 16 - box.y_offset);
+                draw_trans_sprite(double_buffer, shadow[static_cast<size_t>(pix)], x * TILE_W - box.x_offset, y * TILE_H - box.y_offset);
             }
         }
     }
@@ -727,7 +726,7 @@ void KDraw::draw_porttextbox(eBubbleStyle bstyle, int chr)
 
 void KDraw::drawmap(void)
 {
-    if (Game.Map.g_map.xsize <= 0)
+    if (Game.Map.MapSize() == 0)
     {
         clear_to_color(double_buffer, 1);
         return;
@@ -845,7 +844,7 @@ int KDraw::is_forestsquare(int fx, int fy)
     {
         return 0;
     }
-    auto mapseg = map_seg[(fy * Game.Map.g_map.xsize) + fx];
+    auto mapseg = map_seg[Game.Map.Clamp(fx, fy)];
     switch (mapseg) //FIXME: The indexes of overworld forest tiles should come from either a map (.tmx) or a script (.lua).
     {
     case 63:

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -630,7 +630,7 @@ void KDraw::draw_midlayer(void)
 
 void KDraw::draw_shadows(void)
 {
-    if (!draw_shadow)
+    if (!Game.Map.draw_shadow)
     {
         return;
     }
@@ -755,7 +755,7 @@ void KDraw::drawmap(void)
     }
 
     clear_bitmap(double_buffer);
-    if (draw_background)
+    if (Game.Map.draw_background)
     {
         draw_backlayer();
     }
@@ -763,7 +763,7 @@ void KDraw::drawmap(void)
     {
         draw_char();
     }
-    if (draw_middle)
+    if (Game.Map.draw_middle)
     {
         draw_midlayer();
     }
@@ -771,7 +771,7 @@ void KDraw::drawmap(void)
     {
         draw_char();
     }
-    if (draw_foreground)
+    if (Game.Map.draw_foreground)
     {
         draw_forelayer();
     }

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -48,7 +48,8 @@ using namespace eSize;
 
 constexpr auto Coords(int tile_x, int tile_y)
 {
-    auto index = std::clamp(g_map.xsize * tile_y + tile_x, 0U, g_map.xsize * g_map.ysize - 1);
+    const auto lastIndex = Game.Map.g_map.xsize * Game.Map.g_map.ysize - 1;
+    auto index = std::clamp(Game.Map.g_map.xsize * tile_y + tile_x, 0U, lastIndex);
     return index;
 }
 
@@ -422,8 +423,9 @@ int KEntityManager::move(t_entity target_entity, signed int dx, signed int dy)
 
     KQEntity& ent = g_ent[target_entity];
 
-    int tile_x = std::clamp(ent.x / TILE_W, 0, int(g_map.xsize * g_map.ysize - 1));
-    int tile_y = std::clamp(ent.y / TILE_H, 0, int(g_map.xsize * g_map.ysize - 1));
+    const int lastIndex = Game.Map.g_map.xsize * Game.Map.g_map.ysize - 1;
+    int tile_x = std::clamp(ent.x / TILE_W, 0, lastIndex);
+    int tile_y = std::clamp(ent.y / TILE_H, 0, lastIndex);
     int oldfacing = ent.facing;
     if (dx < 0)
     {
@@ -441,8 +443,8 @@ int KEntityManager::move(t_entity target_entity, signed int dx, signed int dy)
     {
         ent.facing = FACE_UP;
     }
-    if (tile_x + dx < 0 || tile_x + dx >= (int)g_map.xsize ||
-        tile_y + dy < 0 || tile_y + dy >= (int)g_map.ysize)
+    if (tile_x + dx < 0 || tile_x + dx >= (int)Game.Map.g_map.xsize ||
+        tile_y + dy < 0 || tile_y + dy >= (int)Game.Map.g_map.ysize)
     {
         return 0;
     }
@@ -641,7 +643,8 @@ int KEntityManager::obstruction(int origin_x, int origin_y, int move_x, int move
 
     // Block entity if it tries to walk off the map
     if ((origin_x == 0 && move_x < 0) || (origin_y == 0 && move_y < 0) ||
-        (origin_x == (int)g_map.xsize - 1 && move_x > 0) || (origin_y == (int)g_map.ysize - 1 && move_y > 0))
+        (origin_x == (int)Game.Map.g_map.xsize - 1 && move_x > 0) ||
+        (origin_y == (int)Game.Map.g_map.ysize - 1 && move_y > 0))
     {
         return 1;
     }

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -652,7 +652,7 @@ int KEntityManager::obstruction(int origin_x, int origin_y, int move_x, int move
     dest_x = origin_x + move_x;
     dest_y = origin_y + move_y;
 
-    // Check the current and target tiles' obstacles
+    // Check the current tile's and target tile's obstacles
     current_tile = Game.Map.obstacle_array[Coords(origin_x, origin_y)];
     target_tile = Game.Map.obstacle_array[Coords(dest_x, dest_y)];
 

--- a/src/intrface.cpp
+++ b/src/intrface.cpp
@@ -894,7 +894,7 @@ static const char* stringreader(lua_State*, void* data, size_t* size)
  */
 static const KMarker* KQ_find_marker(string name, bool required)
 {
-    auto found_marker = g_map.markers.GetMarker(name);
+    auto found_marker = Game.Map.g_map.markers.GetMarker(name);
     if (found_marker != nullptr)
     {
         return found_marker;
@@ -942,9 +942,9 @@ static int get_field(const char* n)
 static void init_markers(lua_State* L)
 {
     lua_newtable(L);
-    for (size_t i = 0; i < g_map.markers.Size(); i++)
+    for (size_t i = 0, ii = Game.Map.g_map.markers.Size(); i < ii; ++i)
     {
-        auto marker = g_map.markers.GetMarker(i);
+        auto marker = Game.Map.g_map.markers.GetMarker(i);
         if (marker != nullptr)
         {
             lua_pushstring(L, marker->name.c_str());
@@ -1493,7 +1493,7 @@ static int KQ_chest(lua_State* L)
          * tile to the given value, and set the zone zero (so we can't search
          * in the same place twice.
          */
-        if (chestx < g_map.xsize || chesty < g_map.ysize)
+        if (chestx < Game.Map.g_map.xsize || chesty < Game.Map.g_map.ysize)
         {
             set_mtile(chestx, chesty, tile);
         }
@@ -1603,8 +1603,8 @@ static int KQ_copy_tile_all(lua_State* L)
     {
         for (i = 0; i < wid; ++i)
         {
-            os = sx + i + g_map.xsize * (sy + j);
-            od = dx + i + g_map.xsize * (dy + j);
+            os = sx + i + Game.Map.g_map.xsize * (sy + j);
+            od = dx + i + Game.Map.g_map.xsize * (dy + j);
             map_seg[od] = map_seg[os];
             f_seg[od] = f_seg[os];
             b_seg[od] = b_seg[os];
@@ -1651,9 +1651,9 @@ static int KQ_door_in(lua_State* L)
     hx = g_ent[0].tilex;
     hy = g_ent[0].tiley;
     hy2 = hy - 1;
-    db = map_seg[hy * g_map.xsize + hx];
-    dt = map_seg[hy2 * g_map.xsize + hx];
-    if (g_map.tileset == 1)
+    db = map_seg[hy * Game.Map.g_map.xsize + hx];
+    dt = map_seg[hy2 * Game.Map.g_map.xsize + hx];
+    if (Game.Map.g_map.tileset == 1)
     {
         set_btile(hx, hy, db + 433);
         if (dt == 149)
@@ -1699,7 +1699,7 @@ static int KQ_door_in(lua_State* L)
 
     // Don't forget to set the door tile back to its "unopened" state
     set_btile(hx, hy, db);
-    if (g_map.tileset == 1)
+    if (Game.Map.g_map.tileset == 1)
     {
         set_btile(hx, hy2, dt);
     }
@@ -1841,7 +1841,7 @@ static int KQ_get_bounds(lua_State* L)
 
         ent_x = g_ent[a].tilex;
         ent_y = g_ent[a].tiley;
-        if (g_map.bounds.IsBound(found_index, ent_x, ent_y, ent_x, ent_y))
+        if (Game.Map.g_map.bounds.IsBound(found_index, ent_x, ent_y, ent_x, ent_y))
         {
             lua_pushnumber(L, found_index);
         }
@@ -2636,7 +2636,7 @@ static int KQ_place_ent(lua_State* L)
 static int KQ_play_map_song(lua_State* L)
 {
     (void)L;
-    Music.play_music(g_map.song_file, 0);
+    Music.play_music(Game.Map.g_map.song_file, 0);
     return 0;
 }
 
@@ -3185,7 +3185,7 @@ static int KQ_set_holdfade(lua_State* L)
 
 static int KQ_set_map_mode(lua_State* L)
 {
-    g_map.map_mode = std::clamp((eMapMode)lua_tonumber(L, 1), eMapMode::MAPMODE_12E3S, eMapMode::MAPMODE_12EP3S);
+    Game.Map.g_map.map_mode = std::clamp((eMapMode)lua_tonumber(L, 1), eMapMode::MAPMODE_12E3S, eMapMode::MAPMODE_12EP3S);
     return 0;
 }
 
@@ -3201,7 +3201,7 @@ static int KQ_set_marker(lua_State* L)
     const int x_coord = lua_tonumber(L, 2);
     const int y_coord = lua_tonumber(L, 3);
 
-    g_map.markers.Add({ marker_name, x_coord, y_coord });
+    Game.Map.g_map.markers.Add({ marker_name, x_coord, y_coord });
     return 0;
 }
 
@@ -3689,10 +3689,10 @@ static int KQ_set_warp(lua_State* L)
 
     if (a == 0 || a == 1)
     {
-        g_map.can_warp = a;
+        Game.Map.g_map.can_warp = a;
     }
-    g_map.warpx = (int)lua_tonumber(L, 2);
-    g_map.warpy = (int)lua_tonumber(L, 3);
+    Game.Map.g_map.warpx = (int)lua_tonumber(L, 2);
+    Game.Map.g_map.warpy = (int)lua_tonumber(L, 3);
     return 0;
 }
 
@@ -4341,31 +4341,31 @@ static int real_entity_num(lua_State* L, int pos)
 
 static void set_btile(int x, int y, int value)
 {
-    map_seg[y * g_map.xsize + x] = value;
+    map_seg[y * Game.Map.g_map.xsize + x] = value;
 }
 
 static void set_mtile(int x, int y, int value)
 {
-    b_seg[y * g_map.xsize + x] = value;
+    b_seg[y * Game.Map.g_map.xsize + x] = value;
 }
 
 static void set_ftile(int x, int y, int value)
 {
-    f_seg[y * g_map.xsize + x] = value;
+    f_seg[y * Game.Map.g_map.xsize + x] = value;
 }
 
 static void set_zone(int x, int y, int value)
 {
-    unsigned int index = std::clamp(y * g_map.xsize + x, 0U, g_map.xsize * g_map.ysize - 1);
+    unsigned int index = std::clamp(y * Game.Map.g_map.xsize + x, 0U, Game.Map.g_map.xsize * Game.Map.g_map.ysize - 1);
     Game.Map.zone_array[index] = value;
 }
 
 static void set_obs(int x, int y, int value)
 {
-    Game.Map.obstacle_array[y * g_map.xsize + x] = static_cast<eObstacle>(value);
+    Game.Map.obstacle_array[y * Game.Map.g_map.xsize + x] = static_cast<eObstacle>(value);
 }
 
 static void set_shadow(int x, int y, int value)
 {
-    Game.Map.shadow_array[y * g_map.xsize + x] = static_cast<eShadow>(value);
+    Game.Map.shadow_array[y * Game.Map.g_map.xsize + x] = static_cast<eShadow>(value);
 }

--- a/src/intrface.cpp
+++ b/src/intrface.cpp
@@ -1587,24 +1587,23 @@ static int KQ_copy_ent(lua_State* L)
  */
 static int KQ_copy_tile_all(lua_State* L)
 {
-    auto sx = lua_tointeger(L, 1);
-    auto sy = lua_tointeger(L, 2);
-    auto dx = lua_tointeger(L, 3);
-    auto dy = lua_tointeger(L, 4);
+    uint32_t sx = lua_tointeger(L, 1);
+    uint32_t sy = lua_tointeger(L, 2);
+    uint32_t dx = lua_tointeger(L, 3);
+    uint32_t dy = lua_tointeger(L, 4);
     uint32_t wid = (uint32_t)lua_tonumber(L, 5);
     uint32_t hgt = (uint32_t)lua_tonumber(L, 6);
-    size_t os, od, i, j;
 
     /*
     sprintf (strbuf, "Copy (%d,%d)x(%d,%d) to (%d,%d)", sx, sy, wid, hgt, dx, dy);
     Game.klog(strbuf);
     */
-    for (j = 0; j < hgt; ++j)
+    for (size_t j = 0; j < hgt; ++j)
     {
-        for (i = 0; i < wid; ++i)
+        for (size_t i = 0; i < wid; ++i)
         {
-            os = sx + i + Game.Map.g_map.xsize * (sy + j);
-            od = dx + i + Game.Map.g_map.xsize * (dy + j);
+            const size_t os = Game.Map.Clamp(sx + i, sy + j);
+            const size_t od = Game.Map.Clamp(dx + i, dy + j);
             map_seg[od] = map_seg[os];
             f_seg[od] = f_seg[os];
             b_seg[od] = b_seg[os];
@@ -1643,16 +1642,13 @@ static int KQ_do_inn_effects(lua_State* L)
 
 static int KQ_door_in(lua_State* L)
 {
-    int hx, hy, hy2, db, dt;
-    int x, y;
-
     use_sstone = 0;
 
-    hx = g_ent[0].tilex;
-    hy = g_ent[0].tiley;
-    hy2 = hy - 1;
-    db = map_seg[hy * Game.Map.g_map.xsize + hx];
-    dt = map_seg[hy2 * Game.Map.g_map.xsize + hx];
+    const int hx = g_ent[0].tilex;
+    const int hy = g_ent[0].tiley;
+    const int hy2 = hy - 1;
+    uint16_t db = map_seg[Game.Map.Clamp(hx, hy)];
+    uint16_t dt = map_seg[Game.Map.Clamp(hx, hy2)];
     if (Game.Map.g_map.tileset == 1)
     {
         set_btile(hx, hy, db + 433);
@@ -1674,6 +1670,7 @@ static int KQ_door_in(lua_State* L)
     Draw.blit2screen();
     kq_wait(50);
 
+    int x = 0, y = 0;
     if (lua_type(L, 1) == LUA_TSTRING)
     {
         /* It's in "marker" form */
@@ -4341,31 +4338,30 @@ static int real_entity_num(lua_State* L, int pos)
 
 static void set_btile(int x, int y, int value)
 {
-    map_seg[y * Game.Map.g_map.xsize + x] = value;
+    map_seg[Game.Map.Clamp(x, y)] = value;
 }
 
 static void set_mtile(int x, int y, int value)
 {
-    b_seg[y * Game.Map.g_map.xsize + x] = value;
+    b_seg[Game.Map.Clamp(x, y)] = value;
 }
 
 static void set_ftile(int x, int y, int value)
 {
-    f_seg[y * Game.Map.g_map.xsize + x] = value;
+    f_seg[Game.Map.Clamp(x, y)] = value;
 }
 
 static void set_zone(int x, int y, int value)
 {
-    unsigned int index = std::clamp(y * Game.Map.g_map.xsize + x, 0U, Game.Map.g_map.xsize * Game.Map.g_map.ysize - 1);
-    Game.Map.zone_array[index] = value;
+    Game.Map.zone_array[Game.Map.Clamp(x, y)] = value;
 }
 
 static void set_obs(int x, int y, int value)
 {
-    Game.Map.obstacle_array[y * Game.Map.g_map.xsize + x] = static_cast<eObstacle>(value);
+    Game.Map.obstacle_array[Game.Map.Clamp(x, y)] = static_cast<eObstacle>(value);
 }
 
 static void set_shadow(int x, int y, int value)
 {
-    Game.Map.shadow_array[y * Game.Map.g_map.xsize + x] = static_cast<eShadow>(value);
+    Game.Map.shadow_array[Game.Map.Clamp(x, y)] = static_cast<eShadow>(value);
 }

--- a/src/intrface.cpp
+++ b/src/intrface.cpp
@@ -2909,7 +2909,7 @@ static int KQ_set_autoparty(lua_State* L)
 
 static int KQ_set_background(lua_State* L)
 {
-    draw_background = ((int)lua_tonumber(L, 1) == 0 ? 0 : 1);
+    Game.Map.draw_background = lua_toboolean(L, 1);
 
     return 0;
 }
@@ -3124,7 +3124,7 @@ static int KQ_set_ent_transl(lua_State* L)
 
 static int KQ_set_foreground(lua_State* L)
 {
-    draw_foreground = ((int)lua_tonumber(L, 1) == 0 ? 0 : 1);
+    Game.Map.draw_foreground = lua_toboolean(L, 1);
 
     return 0;
 }
@@ -3204,7 +3204,7 @@ static int KQ_set_marker(lua_State* L)
 
 static int KQ_set_midground(lua_State* L)
 {
-    draw_middle = ((int)lua_tonumber(L, 1) == 0 ? 0 : 1);
+    Game.Map.draw_middle = lua_toboolean(L, 1);
 
     return 0;
 }

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -93,8 +93,11 @@ int steps = 0;
 /*! 23: various global bitmaps */
 Raster *double_buffer, *fx_buffer, *map_icons[MAX_TILES], *back, *tc, *tc2, *bub[8], *b_shield, *b_shell, *b_repulse,
     *b_mp, *cframes[NUM_FIGHTERS][MAXCFRAMES], *tcframes[NUM_FIGHTERS][MAXCFRAMES], *frames[MAXCHRS][MAXFRAMES],
-    *eframes[MAXE][MAXEFRAMES], *pgb[9], *bord[8], *menuptr, *mptr, *sptr, *stspics, *sicons, *bptr,
+    *pgb[9], *bord[8], *menuptr, *mptr, *sptr, *stspics, *sicons, *bptr,
     *missbmp, *noway, *upptr, *dnptr, *shadow[MAX_SHADOWS], *kfonts;
+
+/*! Enemy animation frames */
+Raster* eframes[MAXE][MAXEFRAMES];
 
 // 5 different colors of fonts, each 8 tall by 6 wide, found within misc.png between (0,100) and (60, 108).
 // sfonts[0] is scanned in, and sfonts[1] through sfonts[4] are simply recolored.

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -419,6 +419,18 @@ KMap::KMap()
 {
 }
 
+size_t KMap::Clamp(signed int tile_x, signed int tile_y) const
+{
+    assert(g_map.xsize > 0 && g_map.ysize > 0);
+    size_t index = std::clamp(tile_x + g_map.xsize * tile_y, 0U, g_map.xsize * g_map.ysize - 1);
+    return index;
+}
+
+size_t KMap::MapSize() const
+{
+    return g_map.xsize * g_map.ysize;
+}
+
 KGame::KGame()
     : WORLD_MAP("main")
     , KQ_TICKS(30)

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -205,10 +205,6 @@ uint8_t do_staff_effect = 0;
 /*! Is the map description is displayed on screen? */
 uint8_t display_desc = 0;
 
-/*! Which map layers should be drawn. These are set when the map is loaded; see change_map()
- */
-uint8_t draw_background = 1, draw_middle = 1, draw_foreground = 1, draw_shadow = 1;
-
 /*! Items in inventory.  */
 s_inventory g_inv[MAX_INV];
 
@@ -413,6 +409,10 @@ int main(int argc, char* argv[])
 
 KMap::KMap()
     : g_map{}
+    , draw_background { true }
+    , draw_middle { true }
+    , draw_foreground { true }
+    , draw_shadow { true }
     , obstacle_array{}
     , shadow_array{}
     , zone_array{}
@@ -1058,13 +1058,16 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
 
     const size_t mapsize = Map.MapSize();
 
-    draw_background = draw_middle = draw_foreground = draw_shadow = 0;
+    Map.draw_background = false;
+    Map.draw_middle = false;
+    Map.draw_foreground = false;
+    Map.draw_shadow = false;
 
     for (size_t i = 0; i < mapsize; ++i)
     {
         if (map_seg[i] > 0)
         {
-            draw_background = 1;
+            Map.draw_background = true;
             break;
         }
     }
@@ -1073,7 +1076,7 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
     {
         if (b_seg[i] > 0)
         {
-            draw_middle = 1;
+            Map.draw_middle = true;
             break;
         }
     }
@@ -1082,7 +1085,7 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
     {
         if (f_seg[i] > 0)
         {
-            draw_foreground = 1;
+            Map.draw_foreground = true;
             break;
         }
     }
@@ -1091,7 +1094,7 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
     {
         if (Map.shadow_array[i] > eShadow::SHADOW_NONE)
         {
-            draw_shadow = 1;
+            Map.draw_shadow = true;
             break;
         }
     }

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -39,15 +39,7 @@
  * fixes
  */
 
-#include <SDL.h>
-#include <SDL_mixer.h>
-#include <cassert>
-#include <clocale>
-#include <cstdio>
-#include <memory>
-#include <string>
-#include <time.h>
-#include <vector>
+#include "kq.h"
 
 #include "animation.h"
 #include "console.h"
@@ -62,7 +54,6 @@
 #include "intrface.h"
 #include "itemdefs.h"
 #include "itemmenu.h"
-#include "kq.h"
 #include "magic.h"
 #include "masmenu.h"
 #include "menu.h"
@@ -79,6 +70,18 @@
 
 #include "gfx.h"
 #include "random.h"
+
+#include <SDL.h>
+#include <SDL_mixer.h>
+#include <cassert>
+#include <clocale>
+#include <cstdio>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+#include <string>
+#include <time.h>
+#include <vector>
 
 using namespace eSize;
 
@@ -105,9 +108,6 @@ uint16_t *map_seg = NULL, *b_seg = NULL, *f_seg = NULL;
 uint8_t progress[SIZE_PROGRESS];
 uint8_t treasure[SIZE_TREASURE];
 uint8_t save_spells[SIZE_SAVE_SPELL];
-
-/*! Current map */
-s_map g_map;
 
 /*! Current entities (players+NPCs) */
 KQEntity g_ent[MAX_ENTITIES];
@@ -305,8 +305,112 @@ s_progress progresses[SIZE_PROGRESS] = {
 };
 #endif
 
+/*! \mainpage KQ - The Classic Computer Role-Playing Game
+ *
+ * Take the part of one of eight mighty heroes as you search for the
+ * Staff of Xenarum.  Visit over twenty different locations, fight a
+ * multitude of evil monsters, wield deadly weapons and cast powerful
+ * spells. On your quest, you will find out how the Oracle knows
+ * everything, who killed the former master of the Embers guild, why
+ * no-one trusts the old man in the manor, and what exactly is
+ * terrorizing the poor Denorians.
+ *
+ * KQ is licensed under the GPL.
+ */
+
+/*! \brief Main function
+ *
+ * Well, this one is pretty obvious.
+ */
+int main(int argc, char* argv[])
+{
+    int stop, game_on, skip_splash;
+
+    setlocale(LC_ALL, "");
+
+    skip_splash = 0;
+    for (int i = 1; i < argc; i++)
+    {
+        if (!strcmp(argv[i], "-nosplash") || !strcmp(argv[i], "--nosplash"))
+        {
+            skip_splash = 1;
+        }
+
+        if (!strcmp(argv[i], "--help"))
+        {
+            printf(_("Sorry, no help screen at this time.\n"));
+            return EXIT_SUCCESS;
+        }
+    }
+
+    Game.startup();
+    game_on = 1;
+    kqrandom = new KQRandom();
+    /* While KQ is running (playing or at startup menu) */
+    while (game_on)
+    {
+        switch (SaveGame.start_menu(skip_splash))
+        {
+        case 0: /* Continue */
+            break;
+        case 1: /* New game */
+            Game.SetGameTime(0);
+            Game.change_map("starting", 0, 0, 0, 0);
+            if (kqrandom)
+            {
+                delete kqrandom;
+            }
+            kqrandom = new KQRandom();
+            break;
+        default: /* Exit */
+            game_on = 0;
+            break;
+        }
+        /* Only show it once at the start */
+        skip_splash = 1;
+        if (game_on)
+        {
+            stop = 0;
+            alldead = 0;
+
+            /* While the actual game is playing */
+            while (!stop)
+            {
+                Game.ProcessEvents();
+                EntityManager.process_entities();
+                Game.do_check_animation();
+                Draw.drawmap();
+                Draw.blit2screen();
+                Music.poll_music();
+                if (Game.want_console)
+                {
+                    Game.want_console = false;
+                    Game.wait_released();
+                    Console.run();
+                }
+                if (PlayerInput.besc())
+                {
+                    stop = SaveGame.system_menu();
+                }
+                if (PlayerInput.bhelp())
+                {
+                    /* TODO: In-game help system. */
+                }
+                if (alldead)
+                {
+                    do_transition(eTransitionFade::IN, 16);
+                    stop = 1;
+                }
+            }
+        }
+    }
+    Game.deallocate_stuff();
+    return EXIT_SUCCESS;
+}
+
 KMap::KMap()
-    : obstacle_array{}
+    : g_map{}
+    , obstacle_array{}
     , shadow_array{}
     , zone_array{}
 {
@@ -365,11 +469,11 @@ void KGame::activate(void)
     looking_at_x += zx;
     looking_at_y += zy;
 
-    q = looking_at_y * g_map.xsize + looking_at_x;
+    q = looking_at_y * Map.g_map.xsize + looking_at_x;
 
-    if (Game.Map.obstacle_array[q] != eObstacle::BLOCK_NONE && Game.Map.zone_array[q] > KZone::ZONE_NONE)
+    if (Map.obstacle_array[q] != eObstacle::BLOCK_NONE && Map.zone_array[q] > KZone::ZONE_NONE)
     {
-        do_zone(Game.Map.zone_array[q]);
+        do_zone(Map.zone_array[q]);
     }
 
     p = EntityManager.entityat(looking_at_x, looking_at_y, 0);
@@ -643,7 +747,7 @@ void KGame::change_map(const string& map_name, int player_x, int player_y, int c
     prepare_map(player_x, player_y, camera_x, camera_y);
 }
 
-void KGame::change_map(const string& map_name, const string& marker_name, int offset_x, int offset_y)
+void KGame::change_map(const string& map_name, const string& marker_name, signed int offset_x, signed int offset_y)
 {
     int msx = 0, msy = 0, mvx = 0, mvy = 0;
 
@@ -651,7 +755,7 @@ void KGame::change_map(const string& map_name, const string& marker_name, int of
     /* Search for the marker with the name passed into the function. Both
      * player's starting position and camera position will be the same
      */
-    auto marker = g_map.markers.GetMarker(marker_name);
+    auto marker = Map.g_map.markers.GetMarker(marker_name);
     if (marker != nullptr)
     {
         msx = mvx = marker->x + offset_x;
@@ -671,33 +775,47 @@ void KGame::do_check_animation(void)
 
 void KGame::data_dump(void)
 {
-    FILE* ff;
-    int a;
-
-    if (debugging > 0)
+    if (debugging <= 0)
     {
-        ff = fopen("treasure.log", "w");
-        if (!ff)
-        {
-            program_death(_("Could not open treasure.log!"));
-        }
-        for (a = 0; a < SIZE_TREASURE; a++)
-        {
-            fprintf(ff, "%d = %d\n", a, treasure[a]);
-        }
-        fclose(ff);
-
-        ff = fopen("progress.log", "w");
-        if (!ff)
-        {
-            program_death(_("Could not open progress.log!"));
-        }
-        for (a = 0; a < SIZE_PROGRESS; a++)
-        {
-            fprintf(ff, "%d: %s = %d\n", progresses[a].num_progress, progresses[a].name, progress[a]);
-        }
-        fclose(ff);
+        return;
     }
+
+    std::ofstream ff;
+    ff.open("treasure.log", std::ios::out);
+    if (!ff)
+    {
+        program_death(_("Could not open treasure.log!"));
+    }
+
+    ff << "List of treasures obtained in KQ:\n\n" << std::flush;
+    for (size_t a = 0; a < SIZE_TREASURE; a++)
+    {
+        if (treasure[a] == 0)
+        {
+            continue;
+        }
+        const int value = treasure[a];
+        ff << a << " = " << value << "\n";
+    }
+    ff.close();
+
+    ff.open("progress.log", std::ios::out);
+    if (!ff)
+    {
+        program_death(_("Could not open progress.log!"));
+    }
+
+    ff << "List of progress in KQ:\n\n" << std::flush;
+    for (size_t a = 0; a < SIZE_PROGRESS; a++)
+    {
+        if (progress[a] == 0)
+        {
+            continue;
+        }
+        const int value = progress[a];
+        ff << progresses[a].num_progress << ": " << progresses[a].name << " = " << value << "\n";
+    }
+    ff.close();
 }
 #endif
 
@@ -801,9 +919,9 @@ void KGame::deallocate_stuff(void)
     {
         free(f_seg);
     }
-    this->Map.zone_array.clear();
-    this->Map.shadow_array.clear();
-    this->Map.obstacle_array.clear();
+    Map.zone_array.clear();
+    Map.shadow_array.clear();
+    Map.obstacle_array.clear();
     if (strbuf)
     {
         free(strbuf);
@@ -918,107 +1036,16 @@ void KGame::load_heroes(void)
         faces->blitTo(players[player_index + 4].portrait, 40, player_index * 40, 0, 0, 40, 40);
     }
 }
-/*! \brief Main function
- *
- * Well, this one is pretty obvious.
- */
-int main(int argc, char* argv[])
-{
-    int stop, game_on, skip_splash;
-
-    setlocale(LC_ALL, "");
-
-    skip_splash = 0;
-    for (int i = 1; i < argc; i++)
-    {
-        if (!strcmp(argv[i], "-nosplash") || !strcmp(argv[i], "--nosplash"))
-        {
-            skip_splash = 1;
-        }
-
-        if (!strcmp(argv[i], "--help"))
-        {
-            printf(_("Sorry, no help screen at this time.\n"));
-            return EXIT_SUCCESS;
-        }
-    }
-
-    Game.startup();
-    game_on = 1;
-    kqrandom = new KQRandom();
-    /* While KQ is running (playing or at startup menu) */
-    while (game_on)
-    {
-        switch (SaveGame.start_menu(skip_splash))
-        {
-        case 0: /* Continue */
-            break;
-        case 1: /* New game */
-            Game.SetGameTime(0);
-            Game.change_map("starting", 0, 0, 0, 0);
-            if (kqrandom)
-            {
-                delete kqrandom;
-            }
-            kqrandom = new KQRandom();
-            break;
-        default: /* Exit */
-            game_on = 0;
-            break;
-        }
-        /* Only show it once at the start */
-        skip_splash = 1;
-        if (game_on)
-        {
-            stop = 0;
-            alldead = 0;
-
-            /* While the actual game is playing */
-            while (!stop)
-            {
-                Game.ProcessEvents();
-                EntityManager.process_entities();
-                Game.do_check_animation();
-                Draw.drawmap();
-                Draw.blit2screen();
-                Music.poll_music();
-                if (Game.want_console)
-                {
-                    Game.want_console = false;
-                    Game.wait_released();
-                    Console.run();
-                }
-                if (PlayerInput.besc())
-                {
-                    stop = SaveGame.system_menu();
-                }
-                if (PlayerInput.bhelp())
-                {
-                    /* TODO: In-game help system. */
-                }
-                if (alldead)
-                {
-                    do_transition(eTransitionFade::IN, 16);
-                    stop = 1;
-                }
-            }
-        }
-    }
-    Game.deallocate_stuff();
-    return EXIT_SUCCESS;
-}
 
 void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
 {
-    Raster* pcxb;
-    unsigned int i;
-    unsigned int o;
+    Raster* pcxb = nullptr;
 
-    size_t mapsize = g_map.xsize * g_map.ysize;
+    const unsigned int mapsize = Map.g_map.xsize * Map.g_map.ysize;
 
     draw_background = draw_middle = draw_foreground = draw_shadow = 0;
 
-    for (i = 0; i < mapsize; i++)
+    for (unsigned int i = 0; i < mapsize; i++)
     {
         if (map_seg[i] > 0)
         {
@@ -1027,7 +1054,7 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
         }
     }
 
-    for (i = 0; i < mapsize; i++)
+    for (unsigned int i = 0; i < mapsize; i++)
     {
         if (b_seg[i] > 0)
         {
@@ -1036,7 +1063,7 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
         }
     }
 
-    for (i = 0; i < mapsize; i++)
+    for (unsigned int i = 0; i < mapsize; i++)
     {
         if (f_seg[i] > 0)
         {
@@ -1045,16 +1072,16 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
         }
     }
 
-    for (i = 0; i < mapsize; i++)
+    for (unsigned int i = 0; i < mapsize; i++)
     {
-        if (this->Map.shadow_array[i] > eShadow::SHADOW_NONE)
+        if (Map.shadow_array[i] > eShadow::SHADOW_NONE)
         {
             draw_shadow = 1;
             break;
         }
     }
 
-    for (i = 0; i < (size_t)numchrs; i++)
+    for (unsigned int i = 0; i < numchrs; i++)
     {
         /* This allows us to either go to the map's default starting coords
          * or specify exactly where on the map to go to (like when there
@@ -1063,7 +1090,7 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
         if (msx == 0 && msy == 0)
         {
             // Place players at default map starting coords
-            EntityManager.place_ent(i, g_map.stx, g_map.sty);
+            EntityManager.place_ent(i, Map.g_map.stx, Map.g_map.sty);
         }
         else
         {
@@ -1076,7 +1103,7 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
         g_ent[i].moving = 0;
     }
 
-    for (i = 0; i < MAX_ENTITIES; i++)
+    for (unsigned int i = 0; i < MAX_ENTITIES; i++)
     {
         // FIXME: This shouldn't be hard-coded into the game engine. Move it to a lua script.
         // The enemy at index 38 within entities.png is a kind of non-moving "black blob" or cloak or something.
@@ -1093,29 +1120,29 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
         }
     }
 
-    pcxb = g_map.map_tiles;
-    for (o = 0; o < (size_t)pcxb->height / TILE_H; o++)
+    pcxb = Map.g_map.map_tiles;
+    for (unsigned int o = 0, oo = static_cast<unsigned int>(pcxb->height / TILE_H); o < oo; ++o)
     {
-        for (i = 0; i < (size_t)pcxb->width / TILE_W; i++)
+        for (unsigned int i = 0, ii = static_cast<unsigned int>(pcxb->width / TILE_W); i < ii; ++i)
         {
-            pcxb->blitTo(map_icons[o * (pcxb->width / TILE_W) + i], i * TILE_W, o * TILE_H, 0, 0, TILE_W, TILE_H);
+            pcxb->blitTo(map_icons[o * ii + i], i * TILE_W, o * TILE_H, 0, 0, TILE_W, TILE_H);
         }
     }
 
-    for (o = 0; o < MAX_ANIM; o++)
+    for (unsigned int o = 0; o < MAX_ANIM; o++)
     {
         adelay[o] = 0;
     }
 
-    Music.play_music(g_map.song_file, 0);
-    mx = g_map.xsize * TILE_W - (19 * TILE_W);
+    Music.play_music(Map.g_map.song_file, 0);
+    mx = (Map.g_map.xsize - 19) * TILE_W; //FIXME: What is this magic '19'?
     /*PH fixme: was 224, drawmap() draws 16 rows, so should be 16*16=256 */
-    my = g_map.ysize * TILE_H - (16 * TILE_H);
+    my = (Map.g_map.ysize - 16) * TILE_H; //FIXME: What is this magic '16'?
 
     if (mvx == 0 && mvy == 0)
     {
-        viewport_x_coord = g_map.stx * TILE_W;
-        viewport_y_coord = g_map.sty * TILE_H;
+        viewport_x_coord = Map.g_map.stx * TILE_W;
+        viewport_y_coord = Map.g_map.sty * TILE_H;
     }
     else
     {
@@ -1125,12 +1152,12 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
 
     calc_viewport();
 
-    for (i = 0; i < MAX_TILES; i++)
+    for (unsigned int i = 0; i < MAX_TILES; i++)
     {
         tilex[i] = (uint16_t)i;
     }
 
-    for (i = 0; i < (size_t)numchrs; i++)
+    for (unsigned int i = 0; i < numchrs; i++)
     {
         g_ent[i].active = true;
     }
@@ -1138,14 +1165,14 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
     EntityManager.number_of_entities = 0;
     EntityManager.count_entities();
 
-    for (i = 0; i < MAX_ENTITIES; i++)
+    for (unsigned int i = 0; i < MAX_ENTITIES; i++)
     {
         g_ent[i].delayctr = 0;
     }
 
     Draw.set_view(0, 0, 0, 0, 0);
 
-    if (g_map.map_desc.length() > 0)
+    if (!Map.g_map.map_desc.empty())
     {
         display_desc = 1;
     }
@@ -1155,7 +1182,7 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
     }
 
     do_luakill();
-    do_luainit(Game.GetCurmap().c_str(), 1);
+    do_luainit(GetCurmap().c_str(), 1);
     do_autoexec();
 
     if (hold_fade == 0 && numchrs > 0)
@@ -1165,8 +1192,8 @@ void KGame::prepare_map(int msx, int msy, int mvx, int mvy)
         do_transition(eTransitionFade::IN, 4);
     }
 
-    use_sstone = g_map.use_sstone;
-    cansave = g_map.can_save;
+    use_sstone = Map.g_map.use_sstone;
+    cansave = Map.g_map.can_save;
     do_postexec();
 }
 
@@ -1263,9 +1290,9 @@ void KGame::startup()
     strbuf = (char*)malloc(4096);
 
     map_seg = b_seg = f_seg = NULL;
-    this->Map.zone_array.clear();
-    this->Map.shadow_array.clear();
-    this->Map.obstacle_array.clear();
+    Map.zone_array.clear();
+    Map.shadow_array.clear();
+    Map.obstacle_array.clear();
 
     allocate_stuff();
 
@@ -1321,7 +1348,7 @@ void KGame::startup()
 
         if (use_joy == 0)
         {
-            Game.klog(_("Only joysticks/gamepads with at least 4 buttons can be used."));
+            klog(_("Only joysticks/gamepads with at least 4 buttons can be used."));
         }
     }
 
@@ -1510,7 +1537,7 @@ void KGame::wait_for_entity(size_t first_entity_index, size_t last_entity_index)
         ProcessEvents();
         EntityManager.process_entities();
         Music.poll_music();
-        Game.do_check_animation();
+        do_check_animation();
         Draw.drawmap();
         Draw.blit2screen();
 
@@ -1576,7 +1603,7 @@ void KGame::zone_check(void)
 
     if (save_spells[P_REPULSE] > 0)
     {
-        if (Game.IsOverworldMap())
+        if (IsOverworldMap())
         {
             save_spells[P_REPULSE]--;
         }
@@ -1598,10 +1625,10 @@ void KGame::zone_check(void)
         }
     }
 
-    unsigned int index = std::clamp(zy * g_map.xsize + zx, 0U, g_map.xsize * g_map.ysize - 1);
-    stc = Game.Map.zone_array[index];
+    unsigned int index = std::clamp(zy * Map.g_map.xsize + zx, 0U, Map.g_map.xsize * Map.g_map.ysize - 1);
+    stc = Map.zone_array[index];
 
-    if (g_map.zero_zone != 0)
+    if (Map.g_map.zero_zone != 0)
     {
         do_zone(stc);
     }
@@ -1647,7 +1674,7 @@ bool KGame::ProcessEvents()
         int rc = SDL_WaitEvent(&event);
         if (rc == 0)
         {
-            Game.program_death("Error waiting for events", SDL_GetError());
+            program_death("Error waiting for events", SDL_GetError());
         }
         do
         {
@@ -1660,7 +1687,7 @@ bool KGame::ProcessEvents()
                 break;
             case SDL_QUIT:
                 // TODO don't be so brutal
-                Game.program_death("SDL quit");
+                program_death("SDL quit");
                 break;
             case SDL_KEYDOWN:
                 PlayerInput.ProcessKeyboardEvent(&event.key);
@@ -1717,18 +1744,6 @@ int KGame::get_key()
     keyp = 0;
     return k;
 }
-/*! \mainpage KQ - The Classic Computer Role-Playing Game
- *
- * Take the part of one of eight mighty heroes as you search for the
- * Staff of Xenarum.  Visit over twenty different locations, fight a
- * multitude of evil monsters, wield deadly weapons and cast powerful
- * spells. On your quest, you will find out how the Oracle knows
- * everything, who killed the former master of the Embers guild, why
- * no-one trusts the old man in the manor, and what exactly is
- * terrorizing the poor Denorians.
- *
- * KQ is licensed under the GPL.
- */
 
 /*! \page treasure A Note on Treasure
  *

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1581,7 +1581,7 @@ void KMagic::special_spells(size_t caster_fighter_index, size_t spell_number)
             }
             else
             {
-                Game.change_map(Game.WORLD_MAP, g_map.warpx, g_map.warpy, g_map.warpx, g_map.warpy);
+                Game.change_map(Game.WORLD_MAP, Game.Map.g_map.warpx, Game.Map.g_map.warpy, Game.Map.g_map.warpx, Game.Map.g_map.warpy);
             }
         }
         break;

--- a/src/masmenu.cpp
+++ b/src/masmenu.cpp
@@ -64,7 +64,7 @@ static int camp_castable(int, int);
  */
 static int camp_castable(int who, int sno)
 {
-    if (sno == M_VISION || (sno == M_WARP && g_map.can_warp == 0))
+    if (sno == M_VISION || (sno == M_WARP && Game.Map.g_map.can_warp == 0))
     {
         return 0;
     }
@@ -492,7 +492,7 @@ static int need_spell(size_t target_fighter_index, size_t spell_number)
          *     you can get away from this battle.  But if you're somewhere that the
          *     map is defined as 'can_warp = 0', you can't use the warp spell there.
          */
-        if (g_map.can_warp == 0)
+        if (Game.Map.g_map.can_warp == 0)
         {
             return 0;
         }

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -70,7 +70,7 @@ static int compose_path(const int* map, uint32_t target_x, uint32_t target_y, ch
 {
     uint32_t x = target_x;
     uint32_t y = target_y;
-    int value = map[y * Game.Map.g_map.xsize + x];
+    int value = map[Game.Map.Clamp(x, y)];
     int index = value - 2;
 
     char temp[1024] = {0};
@@ -79,7 +79,7 @@ static int compose_path(const int* map, uint32_t target_x, uint32_t target_y, ch
     while (value > 1)
     {
         /*  move as many squares up as possible  */
-        while ((y > 0) && (map[(y - 1) * Game.Map.g_map.xsize + x] == (value - 1)) && (value > 1))
+        while ((y > 0) && (map[Game.Map.Clamp(x, y - 1)] == (value - 1)) && (value > 1))
         {
             value--;
             y--;
@@ -87,7 +87,7 @@ static int compose_path(const int* map, uint32_t target_x, uint32_t target_y, ch
         }
 
         /*  move as many squares left as possible  */
-        while ((x > 0) && (map[y * Game.Map.g_map.xsize + (x - 1)] == (value - 1)) && (value > 1))
+        while ((x > 0) && (map[Game.Map.Clamp(x - 1, y)] == (value - 1)) && (value > 1))
         {
             value--;
             x--;
@@ -95,7 +95,7 @@ static int compose_path(const int* map, uint32_t target_x, uint32_t target_y, ch
         }
 
         /*  move as many squares down as possible  */
-        while ((y < Game.Map.g_map.ysize - 1) && (map[(y + 1) * Game.Map.g_map.xsize + x] == (value - 1)) && (value > 1))
+        while ((y < Game.Map.g_map.ysize - 1) && (map[Game.Map.Clamp(x, y + 1)] == (value - 1)) && (value > 1))
         {
             value--;
             y++;
@@ -103,7 +103,7 @@ static int compose_path(const int* map, uint32_t target_x, uint32_t target_y, ch
         }
 
         /*  move as many squares right as possible  */
-        while ((x < Game.Map.g_map.xsize - 1) && (map[y * Game.Map.g_map.xsize + (x + 1)] == (value - 1)) && (value > 1))
+        while ((x < Game.Map.g_map.xsize - 1) && (map[Game.Map.Clamp(x + 1, y)] == (value - 1)) && (value > 1))
         {
             value--;
             x++;
@@ -128,8 +128,7 @@ static void copy_map(int* map)
     {
         for (size_t x = 0; x < Game.Map.g_map.xsize; x++)
         {
-            size_t index = y * Game.Map.g_map.xsize + x;
-
+            const size_t index = Game.Map.Clamp(x, y);
             if (Game.Map.obstacle_array[index] != eObstacle::BLOCK_NONE)
             {
                 map[index] = -1;
@@ -143,7 +142,7 @@ static void copy_map(int* map)
     {
         if (g_ent[entity_index].active)
         {
-            map[g_ent[entity_index].tilex * Game.Map.g_map.ysize + g_ent[entity_index].tiley] = -1;
+            map[Game.Map.Clamp(g_ent[entity_index].tilex, g_ent[entity_index].tiley)] = -1;
         }
     }
 }
@@ -177,7 +176,7 @@ int find_path(size_t entity_id, uint32_t source_x, uint32_t source_y, uint32_t t
 
     memset(buffer, '\0', size);
 
-    int* map = (int*)calloc(Game.Map.g_map.xsize * Game.Map.g_map.ysize, sizeof(int));
+    int* map = (int*)calloc(Game.Map.MapSize(), sizeof(int));
     if (map == nullptr)
     {
         return 3;

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -70,7 +70,7 @@ static int compose_path(const int* map, uint32_t target_x, uint32_t target_y, ch
 {
     uint32_t x = target_x;
     uint32_t y = target_y;
-    int value = map[y * g_map.xsize + x];
+    int value = map[y * Game.Map.g_map.xsize + x];
     int index = value - 2;
 
     char temp[1024] = {0};
@@ -79,7 +79,7 @@ static int compose_path(const int* map, uint32_t target_x, uint32_t target_y, ch
     while (value > 1)
     {
         /*  move as many squares up as possible  */
-        while ((y > 0) && (map[(y - 1) * g_map.xsize + x] == (value - 1)) && (value > 1))
+        while ((y > 0) && (map[(y - 1) * Game.Map.g_map.xsize + x] == (value - 1)) && (value > 1))
         {
             value--;
             y--;
@@ -87,7 +87,7 @@ static int compose_path(const int* map, uint32_t target_x, uint32_t target_y, ch
         }
 
         /*  move as many squares left as possible  */
-        while ((x > 0) && (map[y * g_map.xsize + (x - 1)] == (value - 1)) && (value > 1))
+        while ((x > 0) && (map[y * Game.Map.g_map.xsize + (x - 1)] == (value - 1)) && (value > 1))
         {
             value--;
             x--;
@@ -95,7 +95,7 @@ static int compose_path(const int* map, uint32_t target_x, uint32_t target_y, ch
         }
 
         /*  move as many squares down as possible  */
-        while ((y < g_map.ysize - 1) && (map[(y + 1) * g_map.xsize + x] == (value - 1)) && (value > 1))
+        while ((y < Game.Map.g_map.ysize - 1) && (map[(y + 1) * Game.Map.g_map.xsize + x] == (value - 1)) && (value > 1))
         {
             value--;
             y++;
@@ -103,7 +103,7 @@ static int compose_path(const int* map, uint32_t target_x, uint32_t target_y, ch
         }
 
         /*  move as many squares right as possible  */
-        while ((x < g_map.xsize - 1) && (map[y * g_map.xsize + (x + 1)] == (value - 1)) && (value > 1))
+        while ((x < Game.Map.g_map.xsize - 1) && (map[y * Game.Map.g_map.xsize + (x + 1)] == (value - 1)) && (value > 1))
         {
             value--;
             x++;
@@ -124,11 +124,11 @@ static int compose_path(const int* map, uint32_t target_x, uint32_t target_y, ch
 static void copy_map(int* map)
 {
     // Set any tile to -1 when there's an obstacle or active (as in, visible on the map) entity there.
-    for (size_t y = 0; y < g_map.ysize; y++)
+    for (size_t y = 0; y < Game.Map.g_map.ysize; y++)
     {
-        for (size_t x = 0; x < g_map.xsize; x++)
+        for (size_t x = 0; x < Game.Map.g_map.xsize; x++)
         {
-            size_t index = y * g_map.xsize + x;
+            size_t index = y * Game.Map.g_map.xsize + x;
 
             if (Game.Map.obstacle_array[index] != eObstacle::BLOCK_NONE)
             {
@@ -143,7 +143,7 @@ static void copy_map(int* map)
     {
         if (g_ent[entity_index].active)
         {
-            map[g_ent[entity_index].tilex * g_map.ysize + g_ent[entity_index].tiley] = -1;
+            map[g_ent[entity_index].tilex * Game.Map.g_map.ysize + g_ent[entity_index].tiley] = -1;
         }
     }
 }
@@ -177,14 +177,14 @@ int find_path(size_t entity_id, uint32_t source_x, uint32_t source_y, uint32_t t
 
     memset(buffer, '\0', size);
 
-    int* map = (int*)calloc(g_map.xsize * g_map.ysize, sizeof(int));
+    int* map = (int*)calloc(Game.Map.g_map.xsize * Game.Map.g_map.ysize, sizeof(int));
     if (map == nullptr)
     {
         return 3;
     }
 
     copy_map(map);
-    uint32_t result = search_paths(entity_id, map, 1, source_x, source_y, target_x, target_y, 0, 0, g_map.xsize, g_map.ysize);
+    uint32_t result = search_paths(entity_id, map, 1, source_x, source_y, target_x, target_y, 0, 0, Game.Map.g_map.xsize, Game.Map.g_map.ysize);
 
     if (result == 0)
     {

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -369,7 +369,7 @@ void config_menu(void)
                         Draw.print_font(double_buffer, 92 + 2, 204, _("...please wait..."), FNORMAL);
                         Draw.blit2screen();
                         sound_init();
-                        Music.play_music(g_map.song_file, 0);
+                        Music.play_music(Game.Map.g_map.song_file, 0);
                     }
                 }
                 Config.set_config_int(NULL, "is_sound", Audio.sound_initialized_and_ready != KAudio::eSoundSystem::NotInitialized);

--- a/src/tiledmap.cpp
+++ b/src/tiledmap.cpp
@@ -108,8 +108,8 @@ tmx_map KTiledMap::load_tmx_map(XMLElement const* root)
     tmx_map smap;
     auto properties = root->FirstChildElement("properties");
 
-    smap.xsize = root->IntAttribute("width");
-    smap.ysize = root->IntAttribute("height");
+    smap.xsize = std::max(0, root->IntAttribute("width"));
+    smap.ysize = std::max(0, root->IntAttribute("height"));
     smap.pmult = smap.pdiv = 1;
     for (auto xprop = properties->FirstChildElement("property"); xprop; xprop = xprop->NextSiblingElement("property"))
     {
@@ -672,15 +672,14 @@ void tmx_map::set_current()
     }
 
     // Zones
-    Game.Map.zone_array.assign(xsize * ysize, KZone::ZONE_NONE);
-    for (auto&& zone : zones)
+    Game.Map.zone_array.assign(Game.Map.MapSize(), KZone::ZONE_NONE);
+    for (const auto& zone : zones)
     {
         for (int i = 0; i < zone.w; ++i)
         {
             for (int j = 0; j < zone.h; ++j)
             {
-                const unsigned int lastIndex = Game.Map.g_map.xsize * Game.Map.g_map.ysize - 1;
-                unsigned int index = std::clamp(static_cast<unsigned int>(i + zone.x + xsize * (j + zone.y)), 0U, lastIndex);
+                const size_t index = Game.Map.Clamp(i + zone.x, j + zone.y);
                 Game.Map.zone_array[index] = zone.n;
             }
         }

--- a/src/tiledmap.cpp
+++ b/src/tiledmap.cpp
@@ -579,27 +579,27 @@ static const uint16_t SHADOW_OFFSET = 200;
 void tmx_map::set_current()
 {
     // general map properties
-    g_map.xsize = xsize;
-    g_map.ysize = ysize;
-    g_map.map_no = map_no;
-    g_map.can_save = can_save;
-    g_map.can_warp = can_warp;
-    g_map.pdiv = pdiv;
-    g_map.pmult = pmult;
-    g_map.map_mode = map_mode;
-    g_map.stx = stx;
-    g_map.sty = sty;
-    g_map.warpx = warpx;
-    g_map.warpy = warpy;
-    g_map.tileset = tileset;
-    g_map.use_sstone = use_sstone;
-    g_map.zero_zone = zero_zone;
-    g_map.map_desc = description;
-    g_map.song_file = song_file;
+    Game.Map.g_map.xsize = xsize;
+    Game.Map.g_map.ysize = ysize;
+    Game.Map.g_map.map_no = map_no;
+    Game.Map.g_map.can_save = can_save;
+    Game.Map.g_map.can_warp = can_warp;
+    Game.Map.g_map.pdiv = pdiv;
+    Game.Map.g_map.pmult = pmult;
+    Game.Map.g_map.map_mode = map_mode;
+    Game.Map.g_map.stx = stx;
+    Game.Map.g_map.sty = sty;
+    Game.Map.g_map.warpx = warpx;
+    Game.Map.g_map.warpy = warpy;
+    Game.Map.g_map.tileset = tileset;
+    Game.Map.g_map.use_sstone = use_sstone;
+    Game.Map.g_map.zero_zone = zero_zone;
+    Game.Map.g_map.map_desc = description;
+    Game.Map.g_map.song_file = song_file;
     // Markers
-    g_map.markers = markers;
+    Game.Map.g_map.markers = markers;
     // Bounding boxes
-    g_map.bounds = bounds;
+    Game.Map.g_map.bounds = bounds;
     // Allocate space for layers
     for (auto&& layer : layers)
     {
@@ -679,7 +679,8 @@ void tmx_map::set_current()
         {
             for (int j = 0; j < zone.h; ++j)
             {
-                unsigned int index = std::clamp(static_cast<unsigned int>(i + zone.x + xsize * (j + zone.y)), 0U, g_map.xsize * g_map.ysize - 1);
+                const unsigned int lastIndex = Game.Map.g_map.xsize * Game.Map.g_map.ysize - 1;
+                unsigned int index = std::clamp(static_cast<unsigned int>(i + zone.x + xsize * (j + zone.y)), 0U, lastIndex);
                 Game.Map.zone_array[index] = zone.n;
             }
         }
@@ -690,9 +691,9 @@ void tmx_map::set_current()
     copy(begin(entities), end(entities), make_checked_array_iterator(g_ent, MAX_ENTITIES, PSIZE));
 
     // Tilemaps
-    g_map.map_tiles = find_tileset(primary_tileset_name).imagedata;
-    g_map.misc_tiles = find_tileset("misc").imagedata;
-    g_map.entity_tiles = find_tileset("entities").imagedata;
+    Game.Map.g_map.map_tiles = find_tileset(primary_tileset_name).imagedata;
+    Game.Map.g_map.misc_tiles = find_tileset("misc").imagedata;
+    Game.Map.g_map.entity_tiles = find_tileset("entities").imagedata;
 
     // Animations
     Animation.clear_animations();


### PR DESCRIPTION
- Moves `g_map` out of global scope and into KMap class.
- Creates `KGame::KMap::Clamp()` method to give an index `[0, size-1]` to avoid index out-of-bound errors.