### PR TITLE
Fix potential memory error

### DIFF
--- a/include/draw.h
+++ b/include/draw.h
@@ -26,8 +26,6 @@
 #include <cstdlib>
 #include <string>
 
-using std::string;
-
 class Raster;
 struct SDL_Window;
 struct SDL_Renderer;
@@ -237,7 +235,7 @@ class KDraw
      * \param   msg String to draw
      * \param   font_index Font index (0..6)
      */
-    void print_font(Raster* where, int sx, int sy, const string& msg, eFontColor font_index);
+    void print_font(Raster* where, int sx, int sy, const std::string& msg, eFontColor font_index);
 
     /*! \brief Calculate font height
      * \param index font index
@@ -267,7 +265,7 @@ class KDraw
      * \param   msg String to draw
      * \param   font_index Font index (0..4)
      */
-    void print_num(Raster* where, int sx, int sy, const string& msg, eFont font_index);
+    void print_num(Raster* where, int sx, int sy, const std::string& msg, eFont font_index);
 
     /*! \brief Display speech/thought bubble
      * \author PH
@@ -394,13 +392,13 @@ class KDraw
      *
      * Extract the next unicode char from a UTF-8 string
      *
-     * \param InString Text to decode
+     * \param iter Text to decode
      * \param cp The next character
      * \return Pointer to after the next character
      * \author PH
      * \date 20071116
      */
-    const char* decode_utf8(const char* InString, uint32_t* cp);
+    std::string::const_iterator decode_utf8(std::string::const_iterator iter, uint32_t* cp);
 
     /*! Boundary adjusted for parallax */
     struct PBound
@@ -552,7 +550,7 @@ class KDraw
 
     /*! \brief Replace all occurrences of "from" with "to" and apply changes back to "str".
      */
-    void replaceAll(string& str, const string& from, const string& to);
+    void replaceAll(std::string& str, const std::string& from, const std::string& to);
 
     /*! \brief Insert character names
      *
@@ -564,7 +562,7 @@ class KDraw
      * \returns a string where any $0 or $1 are replaced by player names, or the original
      * string if none found.
      */
-    string parse_string(const string& the_string);
+    std::string parse_string(const std::string& the_string);
 
     // The internal processing modes during text reformatting; used in \sa relay()
     enum m_mode

--- a/include/enemyc.h
+++ b/include/enemyc.h
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <string>
 
 class KFighter;
 
@@ -191,9 +192,9 @@ class KEnemy
     /*! Index related to enemies in an encounter */
     int cf[NUM_FIGHTERS];
 
-    void LoadEnemies(const string& fullPath, Raster* enemy_gfx);
+    void LoadEnemies(const std::string& fullPath, Raster* enemy_gfx);
 
-    void LoadEnemyStats(const string& path_resabil);
+    void LoadEnemyStats(const std::string& path_resabil);
 };
 
 extern KEnemy Enemy;

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -970,105 +970,105 @@ string KDraw::parse_string(const string& the_string)
     return output;
 }
 
-const char* KDraw::decode_utf8(const char* InString, uint32_t* cp)
+string::const_iterator KDraw::decode_utf8(string::const_iterator it, uint32_t* cp)
 {
-    char ch = *InString;
-
+    char ch = *it;
+    bool ok = true;
     if ((ch & 0x80) == 0x0)
     {
         /* single byte */
         *cp = (int)ch;
-        ++InString;
+        ++it;
     }
     else if ((ch & 0xe0) == 0xc0)
     {
         /* double byte */
         *cp = ((ch & 0x1f) << 6);
-        ++InString;
-        ch = *InString;
+        ++it;
+        ch = *it;
 
         if ((ch & 0xc0) == 0x80)
         {
             *cp |= (ch & 0x3f);
-            ++InString;
+            ++it;
         }
         else
         {
-            InString = NULL;
+            ok = false;
         }
     }
     else if ((ch & 0xf0) == 0xe0)
     {
         /* triple */
         *cp = (ch & 0x0f) << 12;
-        ++InString;
-        ch = *InString;
+        ++it;
+        ch = *it;
         if ((ch & 0xc0) == 0x80)
         {
             *cp |= (ch & 0x3f) << 6;
-            ++InString;
-            ch = *InString;
+            ++it;
+            ch = *it;
             if ((ch & 0xc0) == 0x80)
             {
                 *cp |= (ch & 0x3f);
-                ++InString;
+                ++it;
             }
             else
             {
-                InString = NULL;
+                ok = false;
             }
         }
         else
         {
-            InString = NULL;
+            ok = false;
         }
     }
     else if ((ch & 0xf8) == 0xe0)
     {
         /* Quadruple */
         *cp = (ch & 0x0f) << 18;
-        ++InString;
-        ch = *InString;
+        ++it;
+        ch = *it;
         if ((ch & 0xc0) == 0x80)
         {
             *cp |= (ch & 0x3f) << 12;
-            ++InString;
-            ch = *InString;
+            ++it;
+            ch = *it;
             if ((ch & 0xc0) == 0x80)
             {
                 *cp |= (ch & 0x3f) << 6;
-                ++InString;
-                ch = *InString;
+                ++it;
+                ch = *it;
                 if ((ch & 0xc0) == 0x80)
                 {
                     *cp |= (ch & 0x3f);
-                    ++InString;
+                    ++it;
                 }
                 else
                 {
-                    InString = NULL;
+                    ok = false;
                 }
             }
             else
             {
-                InString = NULL;
+                ok = false;
             }
         }
         else
         {
-            InString = NULL;
+            ok = false;
         }
     }
     else
     {
-        InString = NULL;
+        ok = false;
     }
 
-    if (InString == NULL)
+    if (!ok)
     {
         Game.program_death(_("UTF-8 decode error"));
     }
-    return InString;
+    return it;
 }
 
 int KDraw::get_glyph_index(uint32_t cp)
@@ -1108,15 +1108,11 @@ void KDraw::print_font(Raster* where, int sx, int sy, const string& msg, eFontCo
     }
     // MagicNumber: font heights for BIG/NORMAL text
     int hgt = font_height(font_index);
-    string chopped_message(msg);
-    while (1)
+    auto msg_iter = msg.cbegin();
+    while (msg_iter != msg.cend())
     {
         uint32_t cc;
-        chopped_message = decode_utf8(chopped_message.c_str(), &cc);
-        if (cc == 0)
-        {
-            break;
-        }
+        msg_iter = decode_utf8(msg_iter, &cc);
         cc = get_glyph_index(cc);
         masked_blit(kfonts, where, cc * 8, font_index * 8, z + sx, sy, 8, hgt);
         z += 8;


### PR DESCRIPTION
This was identified by the address sanitizer when calling print_font
with an empty string. The appearance depends on contents of memory
just after the string so does not always happen.