### PR TITLE
Update to the splash screen credits

### DIFF
--- a/include/credits.h
+++ b/include/credits.h
@@ -21,16 +21,47 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+#include <vector>
+
 class Raster;
 
-/*! \brief Allocate memory for credits display. */
-void allocate_credits();
+class KCredits
+{
+  public:
+    ~KCredits() = default;
+    KCredits();
 
-/*! \brief Deallocate memory. */
-void deallocate_credits();
+    /*! \brief Allocate memory for credits display. */
+    void allocate_credits();
 
-/*! \brief Display credits (call in a loop).
- *
- * \param double_buffer Where to render onto.
- */
-void display_credits(Raster* double_buffer);
+    /*! \brief Deallocate memory. */
+    void deallocate_credits();
+
+    /*! \brief Display credits (call in a loop).
+     *
+     * \param double_buffer Buffer to draw onto.
+     * \param ease_speed How quickly the lines ease in and out.
+     */
+    void display_credits(Raster* double_buffer, int ease_speed = 1);
+
+  protected:
+    /*! \brief An S-shaped curve.
+     *
+     * Returns values from an 'ease' curve, generally 3*x^2 - 2*x^3,
+     * but clamped to [0..num_ease_values] (inclusive).
+     *
+     * \param   x Where to evaluate the function.
+     * \returns Clamped integer value in range [0..num_ease_values].
+     */
+    int ease(int x);
+
+  private:
+    int num_ease_values;
+    std::vector<int> ease_table;
+    std::unique_ptr<Raster> wk;
+    std::vector<std::string>::iterator cc;
+};
+
+extern KCredits Credits;

--- a/src/credits.cpp
+++ b/src/credits.cpp
@@ -143,7 +143,8 @@ void KCredits::display_credits(Raster* double_buffer, int ease_speed)
     {
         blit(wk.get(), double_buffer, i, ease(i + ease_amount), i + x0, eSize::SCREEN_H - 55, 1, 32);
     }
-    Draw.print_font(double_buffer, (eSize::SCREEN_W - strlen(pressf1) * FontWidth) / 2, eSize::SCREEN_H - 30, pressf1, FNORMAL);
+    Draw.print_font(double_buffer, (eSize::SCREEN_W - strlen(pressf1) * FontWidth) / 2, eSize::SCREEN_H - 30, pressf1,
+                    FNORMAL);
 #ifdef KQ_CHEATS
     /* Put an un-ignorable cheat message; this should stop
      * PH releasing versions with cheat mode compiled in ;)

--- a/src/credits.cpp
+++ b/src/credits.cpp
@@ -29,6 +29,7 @@
 #include "draw.h"
 #include "gettext.h"
 #include "gfx.h"
+#include "random.h"
 
 #include <string>
 #include <vector>
@@ -71,6 +72,12 @@ const int FontWidth = 8;
 
 void KCredits::allocate_credits()
 {
+    // Randomize the credits from item 5 to the end.
+    for (int i = 6, ii = credits.size(); i < ii; ++i)
+    {
+        int index = kqrandom->random_range_exclusive(i, ii);
+        std::swap(credits[i - 1], credits[index]);
+    }
     if (wk == nullptr)
     {
         unsigned int tlen = 0;

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -663,7 +663,7 @@ void KGame::allocate_stuff()
 #ifdef DEBUGMODE
     alloc_bmp(0, 0, nullptr);
 #endif
-    allocate_credits();
+    Credits.allocate_credits();
 }
 
 void KGame::calc_viewport()
@@ -930,7 +930,7 @@ void KGame::deallocate_stuff()
         Music.shutdown_music();
         Music.free_samples();
     }
-    deallocate_credits();
+    Credits.deallocate_credits();
     clear_image_cache();
 
 #ifdef DEBUGMODE

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -324,9 +324,9 @@ int main(int argc, char* argv[])
         }
     }
 
+    kqrandom = new KQRandom();
     Game.startup();
     game_on = 1;
-    kqrandom = new KQRandom();
     /* While KQ is running (playing or at startup menu) */
     while (game_on)
     {

--- a/src/sgame.cpp
+++ b/src/sgame.cpp
@@ -526,7 +526,9 @@ int KSaveGame::start_menu(bool skip_splash)
             draw_sprite(double_buffer, menuptr, 112, ptr * 8 + 124);
             redraw = 0;
         }
-        display_credits(double_buffer);
+
+        const int ease_speed = 4; // Larger value == faster, albeit not as smooth.
+        Credits.display_credits(double_buffer, ease_speed);
         Draw.blit2screen();
         if (PlayerInput.bhelp())
         {


### PR DESCRIPTION
- Moves the functions for setting up and displaying credits into its own `KCredits` class.
- Adds a parameter to display_credits() to make the ease in/out speed adjustable.
- Updated the copyright year from 2021 to 2022.
- Added this repo's URL to the list.

I did _not_ rearrange the existing credits, although I was sorely tempted to do so.

Also @teamterradactyl: Do you want your real name in there, or do you want to leave your pseudonym as-is?