### PR TITLE
sprintf() but for std::string instead of char[]

### DIFF
--- a/include/gfx.h
+++ b/include/gfx.h
@@ -134,13 +134,6 @@ inline void rect(Raster* r, int x1, int y1, int x2, int y2, int c)
     r->hline(x1, x2, y2, c);
 }
 
-/*! \brief Do some kind of printf formatting on the text (unused).
- *
- * \param   fmt Start of va_list.
- * \param   ... va_list args.
- */
-void textprintf(Raster*, void*, int, int, int, const char* fmt, ...);
-
 void set_window_palette(SDL_Window* w);
 
 inline void fullblit(Raster* src, Raster* dest)

--- a/include/kq.h
+++ b/include/kq.h
@@ -44,6 +44,7 @@
 #include "maps.h"
 #include "player.h"
 #include "structs.h"
+#include "utilities.h"
 
 #include <cstdint>
 #include <string>
@@ -572,7 +573,8 @@ extern uint8_t hold_fade, cansave, skip_intro, wait_retrace, windowed, cpu_usage
 extern bool should_stretch_view;
 extern int window_width, window_height;
 extern uint16_t tilex[MAX_TILES], adelay[MAX_ANIM];
-extern char *strbuf, *savedir;
+extern std::string strbuf;
+extern char *savedir;
 extern s_heroinfo players[MAXCHRS];
 extern KFighter fighter[NUM_FIGHTERS];
 extern KFighter tempa, tempd;

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -1,0 +1,59 @@
+/**
+   KQ is Copyright (C) 2002 by Josh Bolduc
+
+   This file is part of KQ... a freeware RPG.
+
+   KQ is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation; either version 2, or (at your
+   option) any later version.
+
+   KQ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with KQ; see the file COPYING.  If not, write to
+   the Free Software Foundation,
+       675 Mass Ave, Cambridge, MA 02139, USA.
+*/
+
+#pragma once
+
+/*! \file Utilities
+ * \brief Various templates and other general-purpose utilities for KQ.
+ */
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+/*! \brief Provide a std::string version of sprintf().
+ *
+ * Allow printf-style formats (such as "%s", "%d", etc.) for std::string types.
+ *
+ * Adapted from https://stackoverflow.com/a/26221725.
+ *
+ * \param[out] dest String to write final output to.
+ * \param[in] format Text containing "%..." style notation to expand.
+ * \param[in] args... Zero or more arguments to pass into snprintf().
+ */
+template<typename... Args> void sprintf(std::string& dest, const std::string& format, Args... args)
+{
+    // This calls snprintf() twice: the first time with NULL for the first parameter
+    // to get the size of the buffer needed to fit all the text into.
+
+    // +1 at end for '\0'.
+    int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) + 1;
+    if (size_s <= 0)
+    {
+        throw std::runtime_error("Error during formatting.");
+    }
+    auto size = static_cast<size_t>(size_s);
+    std::unique_ptr<char[]> buf(new char[size]);
+    std::snprintf(buf.get(), size, format.c_str(), args...);
+
+    // -1 at end to remove the '\0'.
+    dest = std::string(buf.get(), buf.get() + size - 1);
+}

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -936,8 +936,8 @@ void KCombat::enemies_win()
     Draw.blit2screen();
     kq_wait(1000);
     sprintf(strbuf, _("%s was defeated!"), party[pidx[0]].name.c_str());
-    Draw.menubox(double_buffer, 152 - (strlen(strbuf) * 4), 48, strlen(strbuf), 1, BLUE);
-    Draw.print_font(double_buffer, 160 - (strlen(strbuf) * 4), 56, strbuf, FNORMAL);
+    Draw.menubox(double_buffer, 152 - (strbuf.size() * 4), 48, strbuf.size(), 1, BLUE);
+    Draw.print_font(double_buffer, 160 - (strbuf.size() * 4), 56, strbuf, FNORMAL);
     Draw.blit2screen();
     Game.wait_enter();
     do_transition(eTransitionFade::OUT, 4);
@@ -1293,8 +1293,8 @@ void KCombat::heroes_win()
         sprintf(strbuf, _("Gained %d xp."), txp);
     }
 
-    Draw.menubox(double_buffer, 152 - (strlen(strbuf) * 4), 8, strlen(strbuf), 1, BLUE);
-    Draw.print_font(double_buffer, 160 - (strlen(strbuf) * 4), 16, strbuf, FNORMAL);
+    Draw.menubox(double_buffer, 152 - (strbuf.size() * 4), 8, strbuf.size(), 1, BLUE);
+    Draw.print_font(double_buffer, 160 - (strbuf.size() * 4), 16, strbuf, FNORMAL);
     Draw.blit2screen();
     fullblit(double_buffer, back);
     for (fighter_index = 0; fighter_index < num_enemies; fighter_index++)
@@ -1322,9 +1322,9 @@ void KCombat::heroes_win()
                 if (check_inventory(found_item, 1) != 0)
                 {
                     sprintf(strbuf, _("%s found!"), items[found_item].name);
-                    Draw.menubox(double_buffer, 148 - (strlen(strbuf) * 4), nr * 24 + 48, strlen(strbuf) + 1, 1, BLUE);
-                    Draw.draw_icon(double_buffer, items[found_item].icon, 156 - (strlen(strbuf) * 4), nr * 24 + 56);
-                    Draw.print_font(double_buffer, 164 - (strlen(strbuf) * 4), nr * 24 + 56, strbuf, FNORMAL);
+                    Draw.menubox(double_buffer, 148 - (strbuf.size() * 4), nr * 24 + 48, strbuf.size() + 1, 1, BLUE);
+                    Draw.draw_icon(double_buffer, items[found_item].icon, 156 - (strbuf.size() * 4), nr * 24 + 56);
+                    Draw.print_font(double_buffer, 164 - (strbuf.size() * 4), nr * 24 + 56, strbuf, FNORMAL);
                     nr++;
                 }
             }

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -123,7 +123,7 @@ void KDraw::set_window(SDL_Window* _window)
 void KDraw::blit2screen()
 {
     static int frame_count = 0;
-    static char fbuf[16] = "---";
+    static std::string fbuf = "---";
     static Uint32 start_time = 0;
     if (show_frate)
     {

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -165,13 +165,13 @@ void KEffects::display_amount(size_t target_fighter_index, eFont font_color, int
                     }
                     if (Combat.GetHealthAdjust(fighter_index) == NODISPLAY)
                     {
-                        sprintf(strbuf, "_");
+                        strbuf = "_";
                     }
                     else
                     {
                         sprintf(strbuf, "%d", abs(Combat.GetHealthAdjust(fighter_index)));
                     }
-                    string_length = strlen(strbuf) * 3;
+                    string_length = strbuf.size() * 3;
                     eFont new_font_color = font_color;
                     if (font_color == FONT_DECIDE)
                     {

--- a/src/eqpmenu.cpp
+++ b/src/eqpmenu.cpp
@@ -368,17 +368,17 @@ static void draw_equippreview(int ch, int ptr, int pp)
         int c1 = fighter[ch].stats[z];
         int c2 = tstats[z];
         sprintf(strbuf, "%d", c1);
-        Draw.print_font(double_buffer, 252 - (strlen(strbuf) * 8), z * 8 + 100, strbuf, FNORMAL);
+        Draw.print_font(double_buffer, 252 - (strbuf.size() * 8), z * 8 + 100, strbuf, FNORMAL);
         Draw.print_font(double_buffer, 260, z * 8 + 100, ">", FNORMAL);
         if (ptr >= 0)
         {
             sprintf(strbuf, "%d", c2);
             if (c1 < c2)
-                Draw.print_font(double_buffer, 300 - (strlen(strbuf) * 8), z * 8 + 100, strbuf, FGREEN);
+                Draw.print_font(double_buffer, 300 - (strbuf.size() * 8), z * 8 + 100, strbuf, FGREEN);
             if (c2 < c1)
-                Draw.print_font(double_buffer, 300 - (strlen(strbuf) * 8), z * 8 + 100, strbuf, FRED);
+                Draw.print_font(double_buffer, 300 - (strbuf.size() * 8), z * 8 + 100, strbuf, FRED);
             if (c1 == c2)
-                Draw.print_font(double_buffer, 300 - (strlen(strbuf) * 8), z * 8 + 100, strbuf, FNORMAL);
+                Draw.print_font(double_buffer, 300 - (strbuf.size() * 8), z * 8 + 100, strbuf, FNORMAL);
         }
     }
     Draw.menubox(double_buffer, 188, 212, 13, 1, BLUE);

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -307,12 +307,3 @@ void Raster::to_rgba32(SDL_Rect* src, SDL_PixelFormat* format, void* pixels, int
         }
     }
 }
-
-void textprintf(Raster*, void*, int, int, int, const char* fmt, ...)
-{
-    char buffer[1024];
-    va_list args;
-    va_start(args, fmt);
-    vsprintf(buffer, fmt, args);
-    va_end(args);
-}

--- a/src/heroc.cpp
+++ b/src/heroc.cpp
@@ -362,7 +362,7 @@ static void combat_draw_spell_menu(int c, int ptr, int pg)
             }
             b = Magic.mp_needed(c, z);
             sprintf(strbuf, "%d", b);
-            Draw.print_font(double_buffer, 222 - (strlen(strbuf) * 8), j * 8 + 32, strbuf, FNORMAL);
+            Draw.print_font(double_buffer, 222 - (strbuf.size() * 8), j * 8 + 32, strbuf, FNORMAL);
             draw_sprite(double_buffer, b_mp, 222, j * 8 + 32);
         }
     }
@@ -1231,11 +1231,11 @@ static void hero_run()
     }
     else
     {
-        sprintf(strbuf, _("Escaped!"));
+        strbuf = _("Escaped!");
     }
 
     static const int FontWidth = 8;
-    int text_center = strlen(strbuf) * (FontWidth / 2);
+    int text_center = strbuf.size() * (FontWidth / 2);
 
     /* TT: slow_computer addition for speed-ups */
     int time_to_show_running_animation = (slow_computer ? 4 : 20);
@@ -1247,7 +1247,7 @@ static void hero_run()
              running_animation_count++)
         {
             clear_bitmap(double_buffer);
-            Draw.menubox(double_buffer, 152 - text_center, 32, strlen(strbuf), 1, BLUE);
+            Draw.menubox(double_buffer, 152 - text_center, 32, strbuf.size(), 1, BLUE);
             Draw.print_font(double_buffer, 160 - text_center, 40, strbuf, FNORMAL);
             for (size_t fighter_index = 0; fighter_index < numchrs; fighter_index++)
             {

--- a/src/hskill.cpp
+++ b/src/hskill.cpp
@@ -792,7 +792,7 @@ int skill_use(size_t attack_fighter_index)
                 if (check_inventory(found_item, 1) != 0)
                 {
                     sprintf(strbuf, _("%s taken!"), items[found_item].name);
-                    Draw.message(strbuf, items[found_item].icon, 0);
+                    Draw.message(strbuf.c_str(), items[found_item].icon, 0);
                 }
             }
             else
@@ -840,7 +840,7 @@ int skill_use(size_t attack_fighter_index)
                 if (check_inventory(found_item, 1) != 0)
                 {
                     sprintf(strbuf, _("%s taken!"), items[found_item].name);
-                    Draw.message(strbuf, items[found_item].icon, 0);
+                    Draw.message(strbuf.c_str(), items[found_item].icon, 0);
                 }
             }
             else

--- a/src/intrface.cpp
+++ b/src/intrface.cpp
@@ -869,7 +869,7 @@ static const KMarker* KQ_find_marker(std::string name, bool required)
     {
         /* Error, marker name not found */
         sprintf(strbuf, _("Marker \"%s\" not found."), name.c_str());
-        lua_pushstring(theL, strbuf);
+        lua_pushstring(theL, strbuf.c_str());
         lua_error(theL);
         /* never returns here... */
     }
@@ -1428,7 +1428,7 @@ static int KQ_chest(lua_State* L)
         Game.AddGold(item_quantity);
         sprintf(strbuf, _("Found %d gp!"), item_quantity);
         play_effect(KAudio::eSound::SND_MONEY, 128);
-        Draw.message(strbuf, 255, 0);
+        Draw.message(strbuf.c_str(), 255, 0);
         if (treasure_index > -1)
         {
             treasure[treasure_index] = 1;
@@ -1476,7 +1476,7 @@ static int KQ_chest(lua_State* L)
             sprintf(strbuf, _("%s ^%d procured!"), items[inventory_index].name, (int)item_quantity);
         }
         play_effect(KAudio::eSound::SND_UNEQUIP, 128);
-        Draw.message(strbuf, items[inventory_index].icon, 0);
+        Draw.message(strbuf.c_str(), items[inventory_index].icon, 0);
         if (treasure_index > -1)
         {
             treasure[treasure_index] = 1;
@@ -1491,7 +1491,7 @@ static int KQ_chest(lua_State* L)
     {
         sprintf(strbuf, _("%s ^%d not taken!"), items[inventory_index].name, (int)item_quantity);
     }
-    Draw.message(strbuf, items[inventory_index].icon, 0);
+    Draw.message(strbuf.c_str(), items[inventory_index].icon, 0);
     return 0;
 }
 

--- a/src/itemmenu.cpp
+++ b/src/itemmenu.cpp
@@ -705,7 +705,7 @@ eItemEffectResult item_effects(size_t attack_fighter_index, size_t fighter_index
         }
         sprintf(strbuf, _("%s learned!"), magic[tmp].name);
         play_effect(KAudio::eSound::SND_TWINKLE, 128);
-        Draw.message(strbuf, magic[tmp].icon, 0);
+        Draw.message(strbuf.c_str(), magic[tmp].icon, 0);
         return ITEM_EFFECT_SUCCESS_MULTIPLE;
     }
     if (ti == I_HPUP)

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -148,7 +148,7 @@ uint16_t tilex[MAX_TILES];
 uint16_t adelay[MAX_ANIM];
 
 /*! Temporary buffer for string operations (used everywhere!) */
-char* strbuf = NULL;
+std::string strbuf;
 
 /*! Initial character data
  *
@@ -920,10 +920,6 @@ void KGame::deallocate_stuff()
     Map.zone_array.clear();
     Map.shadow_array.clear();
     Map.obstacle_array.clear();
-    if (strbuf)
-    {
-        free(strbuf);
-    }
 
     if (Audio.sound_initialized_and_ready != KAudio::eSoundSystem::NotInitialized)
     {
@@ -1290,9 +1286,6 @@ void KGame::startup()
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_DEBUG);
 #endif
 
-    /* Buffers to allocate */
-    strbuf = (char*)malloc(4096);
-
     map_seg = b_seg = f_seg = NULL;
     Map.zone_array.clear();
     Map.shadow_array.clear();
@@ -1479,7 +1472,7 @@ void KGame::extra_controls()
     auto key = SDL_GetKeyboardState(nullptr);
     if (key[SDL_SCANCODE_X] && key[SDL_SCANCODE_LALT])
     {
-        sprintf(strbuf, _("Program terminated: user pressed Alt+X"));
+        strbuf = _("Program terminated: user pressed Alt+X");
         program_death(strbuf);
     }
 #ifdef DEBUGMODE

--- a/src/masmenu.cpp
+++ b/src/masmenu.cpp
@@ -128,7 +128,7 @@ static void camp_draw_spell_menu(size_t caster_fighter_index, size_t spell_page,
             Draw.draw_icon(double_buffer, magic[spell_index].icon, 96, current_spell * 8 + 100);
             Draw.print_font(double_buffer, 104, current_spell * 8 + 100, magic[spell_index].name, text_color);
             sprintf(strbuf, "%d", Magic.mp_needed(caster_fighter_index, spell_index));
-            Draw.print_font(double_buffer, 232 - (strlen(strbuf) * 8), current_spell * 8 + 100, strbuf, text_color);
+            Draw.print_font(double_buffer, 232 - (strbuf.size() * 8), current_spell * 8 + 100, strbuf, text_color);
         }
     }
     Draw.menubox(double_buffer, 40, 204, 28, 1, BLUE);
@@ -369,7 +369,7 @@ int learn_new_spells(int who)
                 if (in_combat == 1)
                 {
                     sprintf(strbuf, _("%s learned %s"), party[who].name.c_str(), magic[a].name);
-                    size_t strbuf_len = strlen(strbuf);
+                    size_t strbuf_len = strbuf.size();
                     fullblit(back, double_buffer);
                     Draw.menubox(double_buffer, 148 - (strbuf_len * 4), 152, strbuf_len + 1, 1, BLUE);
                     Draw.draw_icon(double_buffer, magic[a].icon, 156 - (strbuf_len * 4), 160);

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -111,9 +111,9 @@ void KMenu::draw_mainmenu(int swho)
     /* PH: print time as h:mm */
     auto gt = Game.GetGameTime();
     sprintf(strbuf, "%d:%02d", gt.hours(), gt.minutes());
-    Draw.print_font(double_buffer, 268 - (strlen(strbuf) * 8), 144, strbuf, FNORMAL);
+    Draw.print_font(double_buffer, 268 - (strbuf.size() * 8), 144, strbuf, FNORMAL);
     sprintf(strbuf, "%d", Game.GetGold());
-    Draw.print_font(double_buffer, 268 - (strlen(strbuf) * 8), 172, strbuf, FNORMAL);
+    Draw.print_font(double_buffer, 268 - (strbuf.size() * 8), 172, strbuf, FNORMAL);
     if (swho != -1)
     {
         Draw.menubox(double_buffer, 44, swho * 64 + 64, 18, 6, DARKBLUE);
@@ -132,22 +132,22 @@ void KMenu::draw_playerstat(Raster* where, int player_index_in_party, int dx, in
     Draw.draw_stsicon(where, 0, player_index_in_party, eSpellType::S_MALISON, dx + 48, dy + 8);
     Draw.print_font(where, dx + 48, dy + 16, _("LV"), FGOLD);
     sprintf(strbuf, "%d", party[player_index_in_party].lvl);
-    Draw.print_font(where, dx + 104 - (strlen(strbuf) * 8), dy + 16, strbuf, FNORMAL);
+    Draw.print_font(where, dx + 104 - (strbuf.size() * 8), dy + 16, strbuf, FNORMAL);
     Draw.print_font(where, dx + 48, dy + 24, _("HP"), FGOLD);
     Draw.print_font(where, dx + 104, dy + 24, "/", FNORMAL);
     sprintf(strbuf, "%d", party[player_index_in_party].hp);
-    j = strlen(strbuf) * 8;
+    j = strbuf.size() * 8;
     Draw.print_font(where, dx + 104 - j, dy + 24, strbuf, FNORMAL);
     sprintf(strbuf, "%d", party[player_index_in_party].mhp);
-    j = strlen(strbuf) * 8;
+    j = strbuf.size() * 8;
     Draw.print_font(where, dx + 144 - j, dy + 24, strbuf, FNORMAL);
     Draw.print_font(where, dx + 48, dy + 32, _("MP"), FGOLD);
     Draw.print_font(where, dx + 104, dy + 32, "/", FNORMAL);
     sprintf(strbuf, "%d", party[player_index_in_party].mp);
-    j = strlen(strbuf) * 8;
+    j = strbuf.size() * 8;
     Draw.print_font(where, dx + 104 - j, dy + 32, strbuf, FNORMAL);
     sprintf(strbuf, "%d", party[player_index_in_party].mmp);
-    j = strlen(strbuf) * 8;
+    j = strbuf.size() * 8;
     Draw.print_font(where, dx + 144 - j, dy + 32, strbuf, FNORMAL);
 }
 
@@ -504,7 +504,7 @@ void KMenu::status_screen(size_t fighter_index)
         Draw.menubox(double_buffer, 0, 72, 18, 17, BLUE);
         Draw.print_font(double_buffer, 8, 80, _("Exp:"), FGOLD);
         sprintf(strbuf, "%d", party[pidx_index].xp);
-        Draw.print_font(double_buffer, 152 - (strlen(strbuf) * 8), 80, strbuf, FNORMAL);
+        Draw.print_font(double_buffer, 152 - (strbuf.size() * 8), 80, strbuf, FNORMAL);
         Draw.print_font(double_buffer, 8, 88, _("Next:"), FGOLD);
         // TT: Does this mean we can only level up to 50?
         if (party[pidx_index].lvl < 50)
@@ -515,7 +515,7 @@ void KMenu::status_screen(size_t fighter_index)
         {
             sprintf(strbuf, "%d", 0);
         }
-        Draw.print_font(double_buffer, 152 - (strlen(strbuf) * 8), 88, strbuf, FNORMAL);
+        Draw.print_font(double_buffer, 152 - (strbuf.size() * 8), 88, strbuf, FNORMAL);
         Draw.print_font(double_buffer, 8, 104, _("Strength"), FGOLD);
         Draw.print_font(double_buffer, 8, 112, _("Agility"), FGOLD);
         Draw.print_font(double_buffer, 8, 120, _("Vitality"), FGOLD);
@@ -541,7 +541,7 @@ void KMenu::status_screen(size_t fighter_index)
             }
             Draw.print_font(double_buffer, 96, stats_y, "$", FGOLD);
             sprintf(strbuf, "%d", fighter[fighter_index].stats[stats_index]);
-            Draw.print_font(double_buffer, 152 - (strlen(strbuf) * 8), stats_y, strbuf, FNORMAL);
+            Draw.print_font(double_buffer, 152 - (strbuf.size() * 8), stats_y, strbuf, FNORMAL);
         }
 
         Draw.menubox(double_buffer, 160, 16, 18, 16, BLUE);

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -241,12 +241,13 @@ void config_menu()
         }
 
         sprintf(strbuf, "%3d%%", gsvol * 100 / 250);
-        citem(row[12], _("Sound Volume:"), strbuf, fontColor);
+        citem(row[12], _("Sound Volume:"), strbuf.c_str(), fontColor);
 
         sprintf(strbuf, "%3d%%", gmvol * 100 / 250);
-        citem(row[13], _("Music Volume:"), strbuf, fontColor);
+        citem(row[13], _("Music Volume:"), strbuf.c_str(), fontColor);
 
-        citem(row[14], _("Slow Computer:"), slow_computer ? _("YES") : _("NO"), FNORMAL);
+        strbuf = slow_computer ? _("YES") : _("NO");
+        citem(row[14], _("Slow Computer:"), strbuf.c_str(), FNORMAL);
 
         if (cpu_usage)
         {
@@ -254,16 +255,20 @@ void config_menu()
         }
         else
         {
-            sprintf(strbuf, "yield_timeslice()");
+            strbuf = "yield_timeslice()";
         }
-        citem(row[15], _("CPU Usage:"), strbuf, FNORMAL);
+        citem(row[15], _("CPU Usage:"), strbuf.c_str(), FNORMAL);
 
 #ifdef DEBUGMODE
         if (debugging)
         {
             sprintf(strbuf, "%d", debugging);
         }
-        citem(row[16], _("DebugMode Stuff:"), debugging ? strbuf : _("OFF"), FNORMAL);
+        else
+        {
+            strbuf = _("OFF");
+        }
+        citem(row[16], _("DebugMode Stuff:"), strbuf.c_str(), FNORMAL);
 #endif
 
         draw_sprite(double_buffer, menuptr, 32, row[ptr]);
@@ -525,7 +530,6 @@ static int getavalue(const char* capt, int minu, int maxu, int cv, bool sp, void
             rectfill(double_buffer, a * 8 + b + 1, 117, a * 8 + b + 7, 123, 50);
             rectfill(double_buffer, a * 8 + b, 116, a * 8 + b + 6, 122, 21);
         }
-        char strbuf[10];
         if (sp)
         {
             sprintf(strbuf, "%d%%", cv * 100 / maxu);
@@ -534,7 +538,7 @@ static int getavalue(const char* capt, int minu, int maxu, int cv, bool sp, void
         {
             sprintf(strbuf, "%d", cv);
         }
-        Draw.print_font(double_buffer, 160 - (strlen(strbuf) * 4), 124, strbuf, FGOLD);
+        Draw.print_font(double_buffer, 160 - (strbuf.size() * 4), 124, strbuf, FGOLD);
         Draw.blit2screen();
 
         if (PlayerInput.left())

--- a/src/sgame.cpp
+++ b/src/sgame.cpp
@@ -182,9 +182,8 @@ void KSaveGame::load_sgstats()
 {
     for (int sg = 0; sg < NUMSG; ++sg)
     {
-        char buf[32];
-        sprintf(buf, "sg%u.xml", sg);
-        std::string path = kqres(eDirectories::SAVE_DIR, std::string(buf));
+        sprintf(strbuf, "sg%u.xml", sg);
+        std::string path = kqres(eDirectories::SAVE_DIR, strbuf);
         s_sgstats& stats = savegame[sg];
         if (Disk.exists(path.c_str()) && (Disk.load_stats_only(path.c_str(), stats) != 0))
         {

--- a/src/shopmenu.cpp
+++ b/src/shopmenu.cpp
@@ -211,7 +211,7 @@ static void buy_menu()
             if (max > 0)
             {
                 sprintf(strbuf, "%d", cost);
-                Draw.print_font(double_buffer, 248 - (strlen(strbuf) * 8), shop_item_index * 8 + 32, strbuf,
+                Draw.print_font(double_buffer, 248 - (strbuf.size() * 8), shop_item_index * 8 + 32, strbuf,
                                 font_color);
             }
             else
@@ -314,7 +314,7 @@ void draw_shopgold()
     Draw.menubox(double_buffer, 248, 208, 7, 2, BLUE);
     Draw.print_font(double_buffer, 256, 216, _("Gold:"), FGOLD);
     sprintf(strbuf, "%d", Game.GetGold());
-    Draw.print_font(double_buffer, 312 - (strlen(strbuf) * 8), 224, strbuf, FNORMAL);
+    Draw.print_font(double_buffer, 312 - (strbuf.size() * 8), 224, strbuf, FNORMAL);
 }
 
 static void draw_sideshot(int selected_item)
@@ -492,12 +492,12 @@ void inn(const char* iname, uint32_t gold_per_character, int pay)
         Draw.menubox(double_buffer, 152 - (strlen(iname) * 4), 0, strlen(iname), 1, BLUE);
         Draw.print_font(double_buffer, 160 - (strlen(iname) * 4), 8, iname, FGOLD);
         sprintf(strbuf, _("The cost is %u gp for the night."), total_gold_cost);
-        Draw.menubox(double_buffer, 152 - (strlen(strbuf) * 4), 48, strlen(strbuf), 1, BLUE);
-        Draw.print_font(double_buffer, 160 - (strlen(strbuf) * 4), 56, strbuf, FNORMAL);
+        Draw.menubox(double_buffer, 152 - (strbuf.size() * 4), 48, strbuf.size(), 1, BLUE);
+        Draw.print_font(double_buffer, 160 - (strbuf.size() * 4), 56, strbuf, FNORMAL);
         Draw.menubox(double_buffer, 248, 168, 7, 2, BLUE);
         Draw.print_font(double_buffer, 256, 176, _("Gold:"), FGOLD);
         sprintf(strbuf, "%d", Game.GetGold());
-        Draw.print_font(double_buffer, 312 - (strlen(strbuf) * 8), 184, strbuf, FNORMAL);
+        Draw.print_font(double_buffer, 312 - (strbuf.size() * 8), 184, strbuf, FNORMAL);
         if ((uint32_t)Game.GetGold() >= total_gold_cost)
         {
             Draw.menubox(double_buffer, 52, 96, 25, 2, BLUE);
@@ -576,7 +576,7 @@ static void sell_howmany(int item_no, size_t inv_page)
     {
         Draw.menubox(double_buffer, 32, 168, 30, 1, DARKBLUE);
         sprintf(strbuf, _("Sell for %d gp?"), prc * 50 / 100);
-        Draw.print_font(double_buffer, 160 - (strlen(strbuf) * 4), 176, strbuf, FNORMAL);
+        Draw.print_font(double_buffer, 160 - (strbuf.size() * 4), 176, strbuf, FNORMAL);
         sell_item(inv_page * NUM_ITEMS_PER_PAGE + item_no, 1);
         stop = 1;
     }
@@ -591,7 +591,7 @@ static void sell_howmany(int item_no, size_t inv_page)
         Draw.draw_icon(double_buffer, items[l].icon, 48, item_no * 8 + 32);
         Draw.print_font(double_buffer, 56, item_no * 8 + 32, items[l].name, FNORMAL);
         sprintf(strbuf, _("%d of %d"), my, max_items);
-        Draw.print_font(double_buffer, 280 - (strlen(strbuf) * 8), item_no * 8 + 32, strbuf, FNORMAL);
+        Draw.print_font(double_buffer, 280 - (strbuf.size() * 8), item_no * 8 + 32, strbuf, FNORMAL);
         Draw.blit2screen();
 
         if (PlayerInput.up() || PlayerInput.right())
@@ -620,7 +620,7 @@ static void sell_howmany(int item_no, size_t inv_page)
         {
             Draw.menubox(double_buffer, 32, 168, 30, 1, DARKBLUE);
             sprintf(strbuf, _("Sell for %d gp?"), (prc * 50 / 100) * my);
-            Draw.print_font(double_buffer, 160 - (strlen(strbuf) * 4), 176, strbuf, FNORMAL);
+            Draw.print_font(double_buffer, 160 - (strbuf.size() * 4), 176, strbuf, FNORMAL);
             sell_item(inv_page * NUM_ITEMS_PER_PAGE + item_no, my);
             stop = 1;
         }
@@ -716,13 +716,13 @@ static void sell_menu()
             {
                 // Check if there is more than one item
                 sprintf(strbuf, _("%d gp for each one."), sp);
-                Draw.print_font(double_buffer, 160 - (strlen(strbuf) * 4), 176, strbuf, FNORMAL);
+                Draw.print_font(double_buffer, 160 - (strbuf.size() * 4), 176, strbuf, FNORMAL);
             }
             else
             {
                 // There is only one of this item
                 sprintf(strbuf, _("That's worth %d gp."), sp);
-                Draw.print_font(double_buffer, 160 - (strlen(strbuf) * 4), 176, strbuf, FNORMAL);
+                Draw.print_font(double_buffer, 160 - (strbuf.size() * 4), 176, strbuf, FNORMAL);
             }
         }
         else


### PR DESCRIPTION
Adds a `utilities.h` file for general-purpose, well, utilities.
- One of these is an overload for `sprintf()` which provides a `std::string` parameter for output.
- I changed our used-everywhere temporary `strbuf` variable from a fixed 4096-byte `char` array to `std::string`.

Something we may want to discuss is whether the signature should remain as the C-style `void sprintf(out_param, in_param, ...)` or switch to `std::string sprintf(in_param, ...)` instead.

The advantage of returning the string would allow us to change:
```c++
    // from this:
    sprintf(strbuf, "%3d>", t1.mhp);
    Draw.print_font(double_buffer, b + 96, 56, strbuf, FNORMAL);

    // to this:
    Draw.print_font(double_buffer, b + 96, 56, sprintf("%3d>", t1.mhp), FNORMAL);
```

I did not do that in this PR because `sprintf(strbuf, ...)` is used _everywhere_ and I wanted to keep the number of changed files to a minimum until we decided on the above.