### PR TITLE
Improve implementation of quest items

### DIFF
--- a/include/draw.h
+++ b/include/draw.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <string>
+#include <vector>
 
 class Raster;
 struct SDL_Window;
@@ -369,6 +370,16 @@ class KDraw
      * \returns Target or a new bitmap.
      */
     Raster* copy_bitmap(Raster* target, Raster* source);
+
+    /*! \brief Lay out some text
+     * Splits the given text at word boundaries so no line is longer
+     * than the given layout width.
+     *
+     * \param text a line of text
+     * \param layout_width the width in characters
+     * \returns the text split into lines
+     */
+    std::vector<std::string> layout(const std::string& text, int layout_width);
 
   private:
     /*! \brief Draw border box.

--- a/include/menu.h
+++ b/include/menu.h
@@ -162,6 +162,15 @@ class KMenu
     void status_screen(size_t fighter_index);
 
     std::vector<KQuestItem> quest_list;
+    /*! \brief Lay out some text
+     * Splits the given text at word boundaries so no line is longer
+     * than the given layout width.
+     *
+     * \param text a line of text
+     * \param layout_width the width in characters
+     * \returns the text split into lines
+     */
+    std::vector<std::string> layout(const std::string& text, int layout_width);
 };
 
 extern KMenu kmenu;

--- a/include/menu.h
+++ b/include/menu.h
@@ -44,7 +44,7 @@ KFighter player2fighter(int who);
  *
  * ... anything, really!
  */
-struct KQuestItem
+struct s_questitem
 {
     /*! The identifying title */
     std::string key;
@@ -151,7 +151,7 @@ class KMenu
      */
     void status_screen(size_t fighter_index);
 
-    std::vector<KQuestItem> quest_list;
+    std::vector<s_questitem> quest_list;
     /*! \brief Lay out some text
      * Splits the given text at word boundaries so no line is longer
      * than the given layout width.

--- a/include/menu.h
+++ b/include/menu.h
@@ -46,16 +46,6 @@ KFighter player2fighter(int who);
  */
 struct KQuestItem
 {
-    KQuestItem()
-    {
-    }
-
-    KQuestItem(const std::string& inKey, const std::string& inText)
-        : key(inKey)
-        , text(inText)
-    {
-    }
-
     /*! The identifying title */
     std::string key;
     /*! The actual info */

--- a/include/menu.h
+++ b/include/menu.h
@@ -152,15 +152,6 @@ class KMenu
     void status_screen(size_t fighter_index);
 
     std::vector<s_questitem> quest_list;
-    /*! \brief Lay out some text
-     * Splits the given text at word boundaries so no line is longer
-     * than the given layout width.
-     *
-     * \param text a line of text
-     * \param layout_width the width in characters
-     * \returns the text split into lines
-     */
-    std::vector<std::string> layout(const std::string& text, int layout_width);
 };
 
 extern KMenu kmenu;

--- a/scripts/global.lua
+++ b/scripts/global.lua
@@ -543,13 +543,11 @@ end
 
 
 function get_quest_info()
-   if LOC_add_quest_item then
-      LOC_add_quest_item()
+   if LOC_get_quest_info then
+      LOC_get_quest_info()
    end
-
-   add_quest_item(_"About...", _"This doesn't do much yet")
-   add_quest_item(_"Test1",    _"Some test info")
-   add_quest_item(_"Sensar",   _"He rages!")
+   -- Add global quest items here:
+   -- add_quest_item("key", "text")
 end
 
 

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -1638,33 +1638,64 @@ void KDraw::resize_window(int w, int h, bool win)
         SDL_SetWindowSize(window, w, h);
     }
 }
-
+/**
+ * Test for a breakpoint.
+ *
+ * A break point is either a white space character or the end of the string.
+ * \param it The position to test.
+ * \param end The end of the string.
+ * \returns true if this is a break point
+ */
 static bool breakpoint(std::string::const_iterator it, std::string::const_iterator end)
 {
     return it == end || isspace(*it);
 }
-static std::string::const_iterator cut(std::string::const_iterator from, std::string::const_iterator end)
+/**
+ * Find the first non-space character.
+ *
+ * Returns the position of the first non-space character after the given position,
+ * or the end of the string if it has nothing but space characters in it.
+ * \param it The position to start.
+ * \param end The end of the string.
+ * \returns the position.
+ */
+static std::string::const_iterator cut(std::string::const_iterator it, std::string::const_iterator end)
 {
-    while (from < end)
+    while (it < end)
     {
-        if (!isspace(*from))
+        if (!isspace(*it))
         {
-            return from;
+            return it;
         }
-        ++from;
+        ++it;
     }
     return end;
 }
+
+/**
+ * Find location of next line break
+ * Starting at the given point, move forward to find a break which will be
+ * either the end of the string, the space following the last word that would
+ * fit in the given width, or a manual break indicated by a LF.
+ * \param begin The starting point of the line.
+ * \param end The end of the text.
+ * \param width The max length of a line.
+ * \returns the position of the break as described above.
+ */
 static std::string::const_iterator next_break(std::string::const_iterator begin, std::string::const_iterator end,
                                               int width)
 {
     auto it = begin;
-    auto prev = std::distance(it,  end) > width ? std::next(it, width) : end;
+    auto prev = std::distance(it, end) > width ? std::next(it, width) : end;
     while (true)
     {
         if (breakpoint(it, end))
         {
-            if (std::distance(begin, it) > width)
+            if (*it == '\n')
+            {
+                return it;
+            }
+            else if (std::distance(begin, it) > width)
             {
                 return prev;
             }

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -1638,3 +1638,59 @@ void KDraw::resize_window(int w, int h, bool win)
         SDL_SetWindowSize(window, w, h);
     }
 }
+
+static bool breakpoint(std::string::const_iterator it, std::string::const_iterator end)
+{
+    return it == end || isspace(*it);
+}
+static std::string::const_iterator cut(std::string::const_iterator from, std::string::const_iterator end)
+{
+    while (from < end)
+    {
+        if (!isspace(*from))
+        {
+            return from;
+        }
+        ++from;
+    }
+    return end;
+}
+static std::string::const_iterator next_break(std::string::const_iterator begin, std::string::const_iterator end,
+                                              int width)
+{
+    auto it = begin;
+    auto prev = std::distance(it,  end) > width ? std::next(it, width) : end;
+    while (true)
+    {
+        if (breakpoint(it, end))
+        {
+            if (std::distance(begin, it) > width)
+            {
+                return prev;
+            }
+            else if (it == end)
+            {
+                return end;
+            }
+            else
+            {
+                prev = it;
+            }
+        }
+        ++it;
+    }
+}
+
+std::vector<std::string> KDraw::layout(const std::string& text, int layout_width)
+{
+    std::vector<std::string> lines;
+    auto end = text.end();
+    auto it = text.begin();
+    while (it != end)
+    {
+        auto brk = next_break(it, end, layout_width);
+        lines.emplace_back(it, brk);
+        it = cut(brk, end);
+    }
+    return lines;
+}

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -273,61 +273,6 @@ void KMenu::menu()
         }
     }
 }
-static bool breakpoint(std::string::const_iterator it, std::string::const_iterator end)
-{
-    return it == end || isspace(*it);
-}
-static std::string::const_iterator cut(std::string::const_iterator from, std::string::const_iterator end)
-{
-    while (from < end)
-    {
-        if (!isspace(*from))
-        {
-            return from;
-        }
-        ++from;
-    }
-    return end;
-}
-static std::string::const_iterator next_break(std::string::const_iterator begin, std::string::const_iterator end,
-                                              int width)
-{
-    auto it = begin;
-    auto prev = std::distance(it,  end) > width ? std::next(it, width) : end;
-    while (true)
-    {
-        if (breakpoint(it, end))
-        {
-            if (std::distance(begin, it) > width)
-            {
-                return prev;
-            }
-            else if (it == end)
-            {
-                return end;
-            }
-            else
-            {
-                prev = it;
-            }
-        }
-        ++it;
-    }
-}
-
-std::vector<std::string> KMenu::layout(const std::string& text, int layout_width)
-{
-    std::vector<std::string> lines;
-    auto end = text.end();
-    auto it = text.begin();
-    while (it != end)
-    {
-        auto brk = next_break(it, end, layout_width);
-        lines.emplace_back(it, brk);
-        it = cut(brk, end);
-    }
-    return lines;
-}
 
 void KMenu::display_quest_window()
 {
@@ -392,7 +337,7 @@ void KMenu::display_quest_window()
             if (current.empty())
             {
                 // Lay this one out if we haven't already
-                current = layout(quest_list[currentQuestSelected].text, ItemTextWidth);
+                current = Draw.layout(quest_list[currentQuestSelected].text, ItemTextWidth);
             }
             int y = MenuboxTopOffset;
             int lastIndex = std::min(textTopIndex + VisibleQuestEntries, (int)current.size());

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -300,6 +300,7 @@ void KMenu::display_quest_window()
     const int ItemTextWidth = 20;
     const int MenuboxTopOffset = TitleTopOffset + 3 * FontHeightFNORMAL; // Top of the upper menubox
     const int MenuboxLeftOffset = 20;
+    const int TextUpDownOffset = MenuboxLeftOffset + (MenuboxWidth + ItemTextWidth + 2) * FontWidthFNORMAL;
 
     int currentQuestSelected = 0;
     // The currently selected info, laid out in lines
@@ -412,12 +413,12 @@ void KMenu::display_quest_window()
             // Draw up & down indicators if there is more text that way
             if (textTopIndex > 0)
             {
-                draw_sprite(double_buffer, upptr, MenuboxLeftOffset + (MenuboxWidth + ItemTextWidth) * FontWidthFNORMAL,
+                draw_sprite(double_buffer, upptr, TextUpDownOffset,
                             MenuboxTopOffset);
             }
             if (textTopIndex + VisibleQuestEntries < current.size())
             {
-                draw_sprite(double_buffer, dnptr, MenuboxLeftOffset + (MenuboxWidth + ItemTextWidth) * FontWidthFNORMAL,
+                draw_sprite(double_buffer, dnptr, TextUpDownOffset,
                             MenuboxTopOffset + FontHeightFNORMAL * (1 + VisibleQuestEntries));
             }
             int newTextTopIndex = textTopIndex;

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -293,7 +293,7 @@ static std::string::const_iterator next_break(std::string::const_iterator begin,
                                               int width)
 {
     auto it = begin;
-    auto prev = std::min(end, std::next(begin, width));
+    auto prev = std::distance(it,  end) > width ? std::next(it, width) : end;
     while (true)
     {
         if (breakpoint(it, end))


### PR DESCRIPTION
The Quest UI (accessible from the 'RETURN' menu)  now shows a selectable list of item names on the left and corresponding text on the right. You can press ALT to switch to the right hand pane and scroll up/down if there is more text than will fit in the box.

However I removed all the item definitions from the scripts (they were just placeholder text) so currently it is not possible to see this view - hopefully I can start to add some items in before 1.0 is ready

Fixes #125 