### PR TITLE
Move cancel action before accept action

### DIFF
--- a/src/sgame.cpp
+++ b/src/sgame.cpp
@@ -274,6 +274,10 @@ int KSaveGame::saveload(int am_saving)
                 am_saving = am_saving - 2;
             }
         }
+        if (PlayerInput.bctrl())
+        {
+            stop = 1;
+        }
         if (PlayerInput.balt())
         {
             switch (am_saving)
@@ -315,10 +319,6 @@ int KSaveGame::saveload(int am_saving)
                 }
                 break;
             }
-        }
-        if (PlayerInput.bctrl())
-        {
-            stop = 1;
         }
     }
     return stop - 1;


### PR DESCRIPTION
Previously if you pressed ALT to load a game then CTRL during the fade
sequence, the cancel would take priority and send you back to the title
screen.

Fixes #144 