### PR TITLE
Music pause/resume restores the previously playing track

### DIFF
--- a/include/music.h
+++ b/include/music.h
@@ -102,9 +102,6 @@ class KMusic
      */
     void* get_sample(const std::string& s);
 
-    /*! \brief Unused. */
-    void play_effect(int /*unused*/, int /*unused*/);
-
     /*! \brief Play the provided Mix_Chunk sample.
      *
      * \param   chunk Mix_Chunk sample data to play.

--- a/include/music.h
+++ b/include/music.h
@@ -117,6 +117,13 @@ class KMusic
   private:
     float mvol = 1.0f;
     float dvol = 1.0f;
+    struct sMusicPos
+    {
+        void* chunk = nullptr;
+        double position = 0.0;
+    };
+    sMusicPos pausedMusic {};
+    void* current;
 };
 
 extern KMusic Music;

--- a/include/setup.h
+++ b/include/setup.h
@@ -48,7 +48,10 @@ class KAudio
   public:
     ~KAudio() = default;
     KAudio();
-
+    bool isReady() const
+    {
+        return sound_initialized_and_ready == eSoundSystem::Ready;
+    }
     eSoundSystem sound_initialized_and_ready;
     bool sound_system_avail;
 };

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -138,7 +138,7 @@ static void citem(int y, const char* caption, const char* value, eFontColor colo
 static void sound_feedback(int val)
 {
     Music.set_volume(val * 10);
-    Music.play_effect(1, 127);
+    play_effect(1, 127);
 }
 
 static void music_feedback(int val)


### PR DESCRIPTION
Re-establishes the behaviour that:
```
Music.pause_music();
Music.play_music(...);
Music.resume_music();
```
will resume the music playing before `pause_music` was called. This is used in battles.
Note that it is intended that the music resumes from where it was paused but SDL2 mixer doesn't implement `Mix_GetMusicPosition` for all music file types. In these cases it'll start from the beginning.

Fixes #143 