### PR TITLE
Random script fixes

### DIFF
--- a/scripts/camp.lua
+++ b/scripts/camp.lua
@@ -50,7 +50,7 @@ end
 
 function entity_handler(en)
   if (en == 0 or en == 1 or en == 3 or en == 4) then
-    bubble(en, _"It sure it clammy in here...")
+    bubble(en, _"It sure is clammy in here...")
 
   elseif (en == 2) then
     -- This should never happen, but just incase...
@@ -404,7 +404,7 @@ function LOC_rescue_mayor(en)
   refresh()
   set_autoparty(1)
 
-  move_entity(HERO1, x + 1, y)
+  set_ent_script(HERO1, "D2R1")
   if (get_numchrs() == 2) then
     move_entity(HERO2, x + 1, y + 1)
   end

--- a/scripts/town1.lua
+++ b/scripts/town1.lua
@@ -170,7 +170,14 @@ function zone_handler(zn)
     change_map("main", "town1")
 
   elseif (zn == 2) then
+    local old_gp = get_gp()
     inn("The Blue Boar Inn", 25, 1)
+    -- This means you MUST stay at an inn before the bridge gets repaired.
+    if (get_gp() < old_gp) then
+      if progress.fightonbridge == 4 then
+        progress.fightonbridge = 5
+        progress.showbridge = 1
+      end
 
   elseif (zn == 3) then
     shop(0)

--- a/scripts/town2.lua
+++ b/scripts/town2.lua
@@ -412,7 +412,7 @@ function zone_handler(zn)
     --    means you must have slept here. */
     local old_gp = get_gp()
     inn("Wayside Inn", 30, 1)
-    -- This means you MUST stay at the inn before the bridge gets repaired.
+    -- This means you MUST stay at an inn before the bridge gets repaired.
     if (get_gp() < old_gp) then
       if progress.fightonbridge == 4 then
         progress.fightonbridge = 5


### PR DESCRIPTION
Apparently it was possible to get a freeze when rescuing Cassandra. move_entity(HERO1 was trying to move left first and got stuck forever. I am guessing its because HERO1 is trying to avoid HERO2.

Also if for some reason you sleep back in ekla instead of randen the bridge wouldnt be built.