### PR TITLE
Fix text layout problems

### DIFF
--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -1406,7 +1406,7 @@ const char* KDraw::relay(const char* buf)
 
     for (i = 0; i < msgbuf.size(); ++i)
     {
-        msgbuf[i].assign(MSG_COLS, '\0');
+        msgbuf[i].clear();
     }
     i = 0;
     cc = 0;
@@ -1429,12 +1429,10 @@ const char* KDraw::relay(const char* buf)
                 break;
 
             case '\0':
-                msgbuf[cr][cc] = '\0';
                 state = M_END;
                 break;
 
             case '\n':
-                msgbuf[cr][cc] = '\0';
                 cc = 0;
                 ++i;
                 if (++cr >= msgbuf.size())
@@ -1455,12 +1453,8 @@ const char* KDraw::relay(const char* buf)
             case ' ':
                 if (cc < MSG_COLS - 1)
                 {
-                    msgbuf[cr][cc] = tc;
+                    msgbuf[cr] += tc;
                     ++cc;
-                }
-                else
-                {
-                    msgbuf[cr][MSG_COLS - 1] = '\0';
                 }
                 ++i;
                 break;
@@ -1483,12 +1477,12 @@ const char* KDraw::relay(const char* buf)
             default:
                 if (cc < MSG_COLS - 1)
                 {
-                    msgbuf[cr][cc] = tc;
+                    msgbuf[cr] += tc;
                     ++cc;
                 }
                 else
                 {
-                    msgbuf[cr][lastc] = '\0';
+                    msgbuf[cr].resize(lastc);
                     ++cr;
                     cc = 0;
                     i = lasts;

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -527,7 +527,7 @@ std::vector<Raster*> KGame::alloc_bmps(const std::string& bitmap_name, const std
         bitmaps[i] = new Raster(bitmap_widths[i], bitmap_heights[i]);
         if (bitmaps[i] == nullptr)
         {
-            sprintf(strbuf, _("ERROR: Could not allocate %s[%zu]!"), bitmap_name, i);
+	    sprintf(strbuf, _("ERROR: Could not allocate %s[%zu]!"), bitmap_name.c_str(), i);
             program_death(strbuf);
         }
     }
@@ -547,7 +547,7 @@ std::vector<Raster*> KGame::alloc_bmps(const size_t total, const std::string& bi
         bitmaps[i] = new Raster(bitmap_width, bitmap_height);
         if (bitmaps[i] == nullptr)
         {
-            sprintf(strbuf, _("ERROR: Could not allocate %s[%zu]!"), bitmap_name, i);
+	    sprintf(strbuf, _("ERROR: Could not allocate %s[%zu]!"), bitmap_name.c_str(), i);
             program_death(strbuf);
         }
     }
@@ -581,7 +581,7 @@ std::vector<std::vector<Raster*>> KGame::alloc_bmps_2d(const size_t rows, const 
             bitmaps[row][col] = new Raster(bitmap_width, bitmap_height);
             if (bitmaps[row][col] == nullptr)
             {
-                sprintf(strbuf, _("ERROR: Could not allocate %s[%zu][%zu]!"), bitmap_name, row, col);
+	        sprintf(strbuf, _("ERROR: Could not allocate %s[%zu][%zu]!"), bitmap_name.c_str(), row, col);
                 program_death(strbuf);
             }
         }


### PR DESCRIPTION
See for example https://github.com/OnlineCop/kq-fork/issues/166#issuecomment-2925689068

The code originally worked on zero-terminated C strings and is moving over to C++ std::strings everywhere. `print_font` used to stop displaying at the first '\0' character but C++ strings can contain '\0' chars and they get displayed as '@'.

This PR also fixes a error signaled by clang (on mac) which, as I understand it, did not signal an error on earlier versions of the compiler but was nonetheless incorrect C++.
